### PR TITLE
fix : add validation check in name textField

### DIFF
--- a/src/ios/PlayGround/PlayGround/Presentation/Register/Register.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/Register.storyboard
@@ -46,6 +46,12 @@
                                             <action selector="nameTextFieldEditingChanged:" destination="Y6W-OH-hqX" eventType="editingChanged" id="kAD-Gi-n6Q"/>
                                         </connections>
                                     </textField>
+                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="본명을 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeY-WQ-Tag">
+                                        <rect key="frame" x="0.0" y="0.0" width="354" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" systemColor="systemRedColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                             </stackView>
                             <textField hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호를 입력해주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZAk-jx-fmo">
@@ -292,6 +298,7 @@
                     <connections>
                         <outlet property="idFormatCheckLabel" destination="R3d-M3-OFo" id="epj-AC-V2d"/>
                         <outlet property="idTextField" destination="LLN-sI-RhG" id="nJV-Lv-W61"/>
+                        <outlet property="nameFormatCheckLabel" destination="DeY-WQ-Tag" id="YFI-CS-32q"/>
                         <outlet property="nameTextField" destination="b86-Q3-iaf" id="wn6-Xj-ULi"/>
                         <outlet property="nextButton" destination="v9p-Os-E8f" id="hQO-t4-MHU"/>
                         <outlet property="sendVerifyMailButton" destination="Xgz-Vh-R8m" id="6Qq-kY-TjT"/>

--- a/src/ios/PlayGround/PlayGround/Presentation/Register/Register.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/Register.storyboard
@@ -344,7 +344,7 @@
                                             <action selector="nickNameTextFieldEditingChanged:" destination="bVU-so-Pye" eventType="editingChanged" id="P5n-Ls-mwI"/>
                                         </connections>
                                     </textField>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최대 6글자까지 입력하실 수 있습니다" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oNn-TW-w6n">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최대 8글자까지 입력하실 수 있습니다" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oNn-TW-w6n">
                                         <rect key="frame" x="0.0" y="49" width="354" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" name="YoutubeBlue"/>
@@ -611,7 +611,7 @@
                                             <action selector="pwTextFieldEditingChanged:" destination="WHa-nn-okS" eventType="editingChanged" id="fQ4-6Z-bVo"/>
                                         </connections>
                                     </textField>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="영문 소문자와 숫자가 포함 6자 이상" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cF1-j8-HnH">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&quot;영문 소문자와 숫자를 포함한 6~16자&quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cF1-j8-HnH">
                                         <rect key="frame" x="0.0" y="49" width="354" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" name="YoutubeBlue"/>

--- a/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/IdInputViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/IdInputViewController.swift
@@ -12,6 +12,7 @@ class IdInputViewController: UIViewController {
     
     // MARK: - Properties
     @IBOutlet weak var nameTextField: UITextField!
+    @IBOutlet weak var nameFormatCheckLabel: UILabel!
     @IBOutlet weak var idFormatCheckLabel: UILabel!
     @IBOutlet weak var idTextField: UITextField!
     @IBOutlet weak var sendVerifyMailButton: UIButton!
@@ -64,6 +65,7 @@ class IdInputViewController: UIViewController {
         }
         if let nameInfo = UserDefaults.standard.string(forKey: "onRegister-Name") {
             nameTextField.text = nameInfo
+            nameFormatCheckLabel.isHidden = isValidName(nameInfo)
         }
         self.sendButtonAvailability()
     }
@@ -87,6 +89,7 @@ class IdInputViewController: UIViewController {
         guard let nameInfo = nameTextField.text, nameInfo.isEmpty == false else {
             return
         }
+        nameFormatCheckLabel.isHidden = isValidName(nameInfo)
         UserDefaults.standard.set(true, forKey: "onRegister")
         UserDefaults.standard.set(nameInfo, forKey: "onRegister-Name")
     }
@@ -119,6 +122,12 @@ class IdInputViewController: UIViewController {
         return emailCheck.evaluate(with: input)
     }
     
+    func isValidName(_ name: String) -> Bool {
+        let nameRegEx = "[가-힣A-Za-z]{1,}"
+        let pred = NSPredicate(format:"SELF MATCHES %@", nameRegEx)
+        return pred.evaluate(with: name)
+    }
+    
     // 인증코드 textField 변경
     @IBAction func verifyNumTextFieldEditingChanged(_ sender: Any) {
         guard let verifyInputInfo = verifyNumTextField.text, verifyInputInfo.isEmpty == false else {
@@ -145,7 +154,7 @@ class IdInputViewController: UIViewController {
     // 인증하기 전송 버튼 활성화
     func sendButtonAvailability() {
         if let nameInfo = nameTextField.text, nameInfo.isEmpty == false, let emailInfo = idTextField.text, emailInfo.isEmpty == false {
-            if isValidEmail(input: emailInfo) {
+            if isValidEmail(input: emailInfo) && isValidName(nameInfo) {
                 sendVerifyMailButton.isEnabled = true
             } else {
                 sendVerifyMailButton.isEnabled = false
@@ -165,6 +174,7 @@ class IdInputViewController: UIViewController {
         nameTextField.resignFirstResponder()
         guard let idInfo = idTextField.text, idInfo.isEmpty == false else { return }
         sendVerifyMailButton.isEnabled = false
+        idFormatCheckLabel.isHidden = true
         UserServiceAPI.shared.sendEmailVerification(email: idInfo) { result in
             print("email send result = \(result)")
             if result == idInfo {

--- a/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/IdInputViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/IdInputViewController.swift
@@ -123,7 +123,7 @@ class IdInputViewController: UIViewController {
     }
     
     func isValidName(_ name: String) -> Bool {
-        let nameRegEx = "[가-힣A-Za-z]{1,}"
+        let nameRegEx = "[가-힣A-Za-z ]{1,}"
         let pred = NSPredicate(format:"SELF MATCHES %@", nameRegEx)
         return pred.evaluate(with: name)
     }

--- a/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/PwInputViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/PwInputViewController.swift
@@ -52,7 +52,7 @@ class PwInputViewController: UIViewController{
             pwCheckValidLabel.text = "비밀번호를 확인해주세요"
             pwCheckValidLabel.textColor = UIColor.systemRed
         } else {
-            pwValidLabel.text = "영문 소문자와 숫자가 포함한 6~16자"
+            pwValidLabel.text = "영문 소문자와 숫자를 포함한 6~16자"
             pwValidLabel.textColor = UIColor.systemRed
             pwCheckValidLabel.isHidden = true
             pwCheckTextField.isEnabled = false


### PR DESCRIPTION
Resolved #84 

원래는 숫자와 특수문자를 필터링하려고 헀는데, 이모지 등도 함께 고려해야 할 것 같아서
[가-힣A-Za-z ] (한글, 영문, 공백)만 입력할 수 있도록 하였습니다.
공백을 허용한 이유는 영문 이름의 경우 공백이 필수일 것 같아서 A-Za-z를 추가한 김에 함께 추가했습니다.