### PR TITLE
chore : exclude chat-service from api-gateway

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -42,8 +42,8 @@ services:
   chat-service:
     container_name: chat-service
     image: rlagksml99/chat-service:latest
-    environment:
-      eureka.client.serviceUrl.defaultZone: http://service-discovery:8761/eureka/
+    ports:
+      - '8888:8888'
     depends_on:
       - redis
     links:
@@ -60,7 +60,7 @@ services:
     networks:
       - sg-network
   apigateway-service:
-    image: api-gateway:1.0
+    image: wodndl895/api-gateway:1.0
     ports:
       - "8000:8000"
     environment:

--- a/src/server/api-gateway/src/main/resources/application.yml
+++ b/src/server/api-gateway/src/main/resources/application.yml
@@ -57,17 +57,3 @@ spring:
           filters:
             - RewritePath=/user-service(?<segment>/?.*), /$\{segment}
 #            - AuthenticationFilter
-        - id: chat-service
-          uri: lb://CHAT-SERVICE
-          predicates:
-            - Path=/chat-service/**
-            - Method=POST,GET,DELETE,PUT
-          filters:
-            - RewritePath=/chat-service/(?<segment>/?.*), /$\{segment}
-        - id: chat-service
-          uri: lb://CHAT-SERVICE
-          predicates:
-            - Path=/chat-service/chat/room/**
-            - Method=POST,GET,DELETE,PUT
-          filters:
-            - RewritePath=/chat-service/(?<segment>/?.*), /$\{segment}

--- a/src/server/chat-service/src/main/resources/application.yml
+++ b/src/server/chat-service/src/main/resources/application.yml
@@ -1,23 +1,12 @@
 spring.profiles.active: local
 server:
-  port: 0
+  port: 8888
 spring:
   devtools:
     livereload:
       enabled: true
     restart:
       enabled: false
-  application:
-    name: chat-service
-eureka:
-  instance:
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
-  client:
-    fetch-registry: true
-    register-with-eureka: true
-    service-url:
-      defaultZone: http://localhost:8761/eureka
-
 ---
 spring.config.activate.on-profile: local
 spring:


### PR DESCRIPTION
- now access to `localhost:8888`, don't use prefix `/chat-service`
```
// load room list
localhost:8888/chat/{roomId}

// create room
localhost:8888/chat/room?name={name}

// create connection to websockt endpoint
localhost:8888/ws
```