### PR TITLE
fix : infinite-scroll change param index -> last pk

### DIFF
--- a/src/server/main-service/src/main/java/com/example/mainservice/controller/MainController.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/controller/MainController.java
@@ -22,16 +22,18 @@ public class MainController {
     private final MainService mainService;
 
     /**
-     *
-     * @param category ALL(기본 홈화면 로드), 그 외(카테고리별 조회)
+     * @param lastId value must be -1 for initial home view (or must be same or bigger than 0)
      */
     @GetMapping("/list")
-    public ResponseEntity<VideoListDto> getVideoList(@RequestParam("category") String category, @RequestParam("page") int page, @RequestParam("size") int size) throws Exception {
-        return ResponseEntity.ok(mainService.getVideoList(Category.valueOf(category), page, size));
+    public ResponseEntity<VideoListDto> getHomeList(@RequestParam("category") String category,
+                                                    @RequestParam("last-id") int lastId,
+                                                    @RequestParam("size") int size) throws Exception {
+        return ResponseEntity.ok(mainService.getHomeList(Category.valueOf(category), lastId, size));
     }
 
     @GetMapping("/notification/{uuid}")
-    public ResponseEntity<Map<String, List<NotificationDto>>> getNotificationList(@PathVariable("uuid") String uuid) throws Exception {
+    public ResponseEntity<Map<String, List<NotificationDto>>> getNotificationList(@PathVariable("uuid") String uuid)
+            throws Exception {
         return ResponseEntity.ok(Map.of(RESPONSE_MAP_KEY, mainService.getNotificationList(uuid)));
     }
 
@@ -49,8 +51,9 @@ public class MainController {
 
     /* TODO : elastic search로 구현*/
     @GetMapping("/search")
-    public ResponseEntity<Map<String, String>> searchVideoByKeyword(@RequestParam("keyword") String keyword, @RequestParam("page") int page,
-                                             @RequestParam("size") int size) throws Exception {
+    public ResponseEntity<Map<String, String>> searchVideoByKeyword(@RequestParam("keyword") String keyword,
+                                                                    @RequestParam("page") int page,
+                                                                    @RequestParam("size") int size) throws Exception {
         //mainService.searchVideoByKeyword(keyword, page, size);
         return ResponseEntity.ok(Map.of(RESPONSE_MAP_KEY, "This API is not developed yet...."));
     }

--- a/src/server/main-service/src/main/java/com/example/mainservice/controller/MainController.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/controller/MainController.java
@@ -22,13 +22,16 @@ public class MainController {
     private final MainService mainService;
 
     /**
-     * @param lastId value must be -1 for initial home view (or must be same or bigger than 0)
+     * <pre>
+     * {lastVideoId, lastLiveRoomId} value must be -1 for initial home view (or must be same or bigger than 0)
+     * </pre>
      */
     @GetMapping("/list")
     public ResponseEntity<VideoListDto> getHomeList(@RequestParam("category") String category,
-                                                    @RequestParam("last-id") int lastId,
+                                                    @RequestParam("last-video") long lastVideoId,
+                                                    @RequestParam("last-live") long lastLiveRoomId,
                                                     @RequestParam("size") int size) throws Exception {
-        return ResponseEntity.ok(mainService.getHomeList(Category.valueOf(category), lastId, size));
+        return ResponseEntity.ok(mainService.getHomeList(Category.valueOf(category), lastVideoId, lastLiveRoomId, size));
     }
 
     @GetMapping("/notification/{uuid}")

--- a/src/server/main-service/src/main/java/com/example/mainservice/entity/LiveRoom/LiveRoomRepository.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/entity/LiveRoom/LiveRoomRepository.java
@@ -1,9 +1,6 @@
 package com.example.mainservice.entity.LiveRoom;
 
-import com.example.mainservice.dto.LiveRoomDto;
 import com.example.mainservice.entity.Category;
-import com.example.mainservice.entity.Video.Video;
-import org.hibernate.metamodel.model.convert.spi.JpaAttributeConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,11 +9,17 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface LiveRoomRepository extends JpaRepository<LiveRoom,Long>{
+public interface LiveRoomRepository extends JpaRepository<LiveRoom, Long> {
 
     @Query("SELECT l FROM LiveRoom l ORDER BY l.createdAt DESC")
     Page<LiveRoom> findAll(Pageable pageable);
 
-    @Query("SELECT l FROM LiveRoom l WHERE l.category=:category ORDER BY l.createdAt DESC")
+    @Query("SELECT l FROM LiveRoom l WHERE l.id < :lastId ORDER BY l.createdAt DESC")
+    Page<LiveRoom> findAll(@Param("lastId") long lastId, Pageable pageable);
+
+    @Query("SELECT l FROM LiveRoom l WHERE l.category=:category  ORDER BY l.createdAt DESC")
     List<LiveRoom> findAllByCategory(@Param("category") Category category, Pageable pageable);
+
+    @Query("SELECT l FROM LiveRoom l WHERE l.category=:category AND l.id <:lastId ORDER BY l.createdAt DESC")
+    List<LiveRoom> findAllByCategory(@Param("category") Category category, @Param("lastId")long lastId, Pageable pageable);
 }

--- a/src/server/main-service/src/main/java/com/example/mainservice/entity/Video/VideoRepository.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/entity/Video/VideoRepository.java
@@ -9,10 +9,17 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface VideoRepository extends JpaRepository<Video, Long>{
+public interface VideoRepository extends JpaRepository<Video, Long> {
+
     @Query("SELECT v FROM Video v ORDER BY v.createdAt DESC")
     Page<Video> findAll(Pageable pageable);
 
+    @Query("SELECT v FROM Video v WHERE v.id < :lastId ORDER BY v.createdAt DESC")
+    Page<Video> findAll(@Param("lastId") long lastId, Pageable pageable);
+
     @Query("SELECT v FROM Video v WHERE v.category =:category ORDER BY v.createdAt DESC")
     List<Video> findAllByCategory(@Param("category") Category category, Pageable pageable);
+
+    @Query("SELECT v FROM Video v WHERE v.category =:category AND v.id < :lastId ORDER BY v.createdAt DESC")
+    List<Video> findAllByCategory(@Param("category") Category category, @Param("lastId") long lastId, Pageable pageable);
 }

--- a/src/server/main-service/src/main/java/com/example/mainservice/service/MainService.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/service/MainService.java
@@ -43,9 +43,9 @@ public class MainService {
     private final ModelMapper mapper;
 
     @Transactional(readOnly = true)
-    public VideoListDto getHomeList(Category category, long lastId, int size) throws Exception{
-        List<VideoDto> videoDtos = getVideoList(category, lastId, size);
-        List<LiveRoomDto> liveRoomDtos = getLiveRoomList(category, lastId, size);
+    public VideoListDto getHomeList(Category category, long lastVideoId, long lastLiveRoomId, int size) throws Exception{
+        List<VideoDto> videoDtos = getVideoList(category, lastVideoId, size);
+        List<LiveRoomDto> liveRoomDtos = getLiveRoomList(category, lastLiveRoomId, size);
         VideoListDto videoListDto = new VideoListDto(videoDtos, liveRoomDtos);
         return videoListDto;
     }

--- a/src/server/main-service/src/main/java/com/example/mainservice/service/MainService.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/service/MainService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,29 +43,56 @@ public class MainService {
     private final ModelMapper mapper;
 
     @Transactional(readOnly = true)
-    public VideoListDto getVideoList(Category category, int page, int size) throws Exception{
-        List<VideoDto> videoDtos = null;
-        List<LiveRoomDto> liveRoomDtos = null;
-        Pageable pageable = PageRequest.of(page, size);
-        if (category == Category.ALL) {
-            videoDtos = videoRepository.findAll(pageable).getContent().stream()
-                    .map(video -> VideoDto.fromEntity(mapper, video))
-                    .collect(Collectors.toList());
-            liveRoomDtos = liveRoomRepository.findAll(pageable).getContent().stream()
-                    .map(liveRoom -> LiveRoomDto.fromEntity(mapper, liveRoom))
-                    .collect(Collectors.toList());
-        } else {
-            videoDtos = videoRepository.findAllByCategory(category, pageable).stream()
-                    .map(video -> VideoDto.fromEntity(mapper, video))
-                    .collect(Collectors.toList());
-            liveRoomDtos = liveRoomRepository.findAllByCategory(category, pageable).stream()
-                    .map(liveRoom -> LiveRoomDto.fromEntity(mapper, liveRoom))
-                    .collect(Collectors.toList());
-        }
+    public VideoListDto getHomeList(Category category, long lastId, int size) throws Exception{
+        List<VideoDto> videoDtos = getVideoList(category, lastId, size);
+        List<LiveRoomDto> liveRoomDtos = getLiveRoomList(category, lastId, size);
         VideoListDto videoListDto = new VideoListDto(videoDtos, liveRoomDtos);
         return videoListDto;
     }
 
+    private List<VideoDto> getVideoList(Category category, long lastId, int size) throws Exception{
+        Stream<Video> videoDtoStream = null;
+        Pageable pageable = PageRequest.of(0, size);
+        if (category == Category.ALL) {
+            if(lastId == -1){
+                videoDtoStream = videoRepository.findAll(pageable).getContent().stream();
+            }
+            else {
+                videoDtoStream = videoRepository.findAll(lastId, pageable).getContent().stream();
+            }
+        } else {
+            if(lastId == -1){
+                videoDtoStream = videoRepository.findAllByCategory(category, pageable).stream();
+            }
+            else {
+                videoDtoStream = videoRepository.findAllByCategory(category, lastId, pageable).stream();
+            }
+        }
+        return videoDtoStream.map(video -> VideoDto.fromEntity(mapper, video))
+                .collect(Collectors.toList());
+    }
+
+    public List<LiveRoomDto> getLiveRoomList(Category category, long lastId, int size) throws Exception{
+        Pageable pageable = PageRequest.of(0, size);
+        Stream<LiveRoom> liveRoomDtoStream = null;
+        if (category == Category.ALL) {
+            if(lastId == -1){
+                liveRoomDtoStream = liveRoomRepository.findAll(pageable).getContent().stream();
+            }
+            else {
+                liveRoomDtoStream = liveRoomRepository.findAll(lastId, pageable).getContent().stream();
+            }
+        } else {
+            if(lastId == -1){
+                liveRoomDtoStream = liveRoomRepository.findAllByCategory(category, pageable).stream();
+            }
+            else {
+                liveRoomDtoStream = liveRoomRepository.findAllByCategory(category, lastId, pageable).stream();
+            }
+        }
+        return liveRoomDtoStream.map(liveRoom -> LiveRoomDto.fromEntity(mapper, liveRoom))
+                .collect(Collectors.toList());
+    }
     @Transactional(readOnly = true)
     public List<NotificationDto> getNotificationList(String uuid) throws Exception {
         UserEntity user = userRepository.findByUuid(uuid).orElseThrow(() -> new CustomMainException(ErrorCode.U002));

--- a/src/server/main-service/src/main/resources/application.yml
+++ b/src/server/main-service/src/main/resources/application.yml
@@ -1,5 +1,10 @@
 spring.profiles.active: local
 spring:
+  datasource:
+    url: jdbc:mariadb://pg-mariadb:3306/playground?serverTimezone=Asia/Seoul&characterEncoding=utf8
+    driver-class-name: org.mariadb.jdbc.Driver
+    username: root
+    password: test
   application:
     name: main-service
   jpa:
@@ -18,23 +23,10 @@ eureka:
     service-url:
       defaultZone: http://localhost:8761/eureka
 ---
+spring.config.activate.on-profile: local
 server:
   port: 8080
-spring.config.activate.on-profile: local
-spring:
-  datasource:
-    url: jdbc:mariadb://localhost:3306/playground?serverTimezone=Asia/Seoul&characterEncoding=utf8
-    driver-class-name: org.mariadb.jdbc.Driver
-    username: root
-    password: test
-
 ---
+spring.config.activate.on-profile: develop
 server:
   port: 0
-spring.config.activate.on-profile: develop
-spring:
-  datasource:
-    url: jdbc:mariadb://pg-mariadb:3306/playground?serverTimezone=Asia/Seoul&characterEncoding=utf8
-    driver-class-name: org.mariadb.jdbc.Driver
-    username: root
-    password: test


### PR DESCRIPTION
## FIX (Updated)
- 무한 스크롤 : page단위가 아닌 마지막 비디오 pk기준으로 수정(가장 처음 로드할 경우 ~last-id~ last-video, last-live= -1로 둡니다)

## Published Postman API Docs (For EXAMPLE REQUEST)
여기서 REST API api document를 볼 수 있습니다.  (**example 참고용으로만 봐주세요!!** 자세한 명세는 api명세서에 다 반영할거에요)
https://documenter.getpostman.com/view/6436497/UVeCQoNH#88e674a6-6671-46e4-b018-17e0d2938072

`Run in postman`으로 example collection을 가져올 수 있습니다. (아마 매번 전체 collection이 새로 **추가** 될거라 기존건 삭제하는 식이 될 것 같습니다)
![image](https://user-images.githubusercontent.com/30483337/151694439-fa19a3b7-5871-431c-a8a6-9c473c346217.png)
