### PR TITLE
feat : connect main-service api under /list

### DIFF
--- a/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
+++ b/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		490770A12797E8D100ADD8E8 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490770A02797E8D100ADD8E8 /* UserManager.swift */; };
 		490770A32797EA7A00ADD8E8 /* KeyChainWrapper+Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490770A22797EA7A00ADD8E8 /* KeyChainWrapper+Key.swift */; };
 		490770A52797F7A300ADD8E8 /* ErrorCodeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490770A42797F7A300ADD8E8 /* ErrorCodeConverter.swift */; };
+		491EF26727A7C2CE00A7AF91 /* String+getDateString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491EF26627A7C2CD00A7AF91 /* String+getDateString.swift */; };
+		491EF26927A7C31000A7AF91 /* UIImageView+downloadImageFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491EF26827A7C31000A7AF91 /* UIImageView+downloadImageFrom.swift */; };
+		49245C4727A3D5C50059DF55 /* MainDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49245C4627A3D5C50059DF55 /* MainDataModel.swift */; };
 		492C62192794F90500AE546E /* LoginNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492C62182794F90500AE546E /* LoginNavigationController.swift */; };
 		492C621B279531F200AE546E /* AccountEditCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492C621A279531F200AE546E /* AccountEditCoordinator.swift */; };
 		492C621D2795320C00AE546E /* PlayerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492C621C2795320C00AE546E /* PlayerCoordinator.swift */; };
@@ -53,6 +56,8 @@
 		49B9C9F2277AF018006AE134 /* UIFont+CustomFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B9C9F1277AF018006AE134 /* UIFont+CustomFont.swift */; };
 		49C52CE0278B4379009D6FBB /* ChannelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C52CDE278B4379009D6FBB /* ChannelViewController.swift */; };
 		49C52CE1278B4379009D6FBB /* Channel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49C52CDF278B4379009D6FBB /* Channel.storyboard */; };
+		49C6CF9F27A3DAAD007C2895 /* MainServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C6CF9E27A3DAAD007C2895 /* MainServiceAPI.swift */; };
+		49C6CFA227A3E080007C2895 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C6CFA127A3E080007C2895 /* HomeViewModel.swift */; };
 		49D7A0AA2783DBB9001CAC60 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D7A0A92783DBB9001CAC60 /* LoginViewController.swift */; };
 		49D7A0AC2783ECAD001CAC60 /* AppUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D7A0AB2783ECAD001CAC60 /* AppUtility.swift */; };
 		49D7A0B527840595001CAC60 /* Register.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49D7A0AD27840595001CAC60 /* Register.storyboard */; };
@@ -97,6 +102,9 @@
 		490770A02797E8D100ADD8E8 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		490770A22797EA7A00ADD8E8 /* KeyChainWrapper+Key.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyChainWrapper+Key.swift"; sourceTree = "<group>"; };
 		490770A42797F7A300ADD8E8 /* ErrorCodeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeConverter.swift; sourceTree = "<group>"; };
+		491EF26627A7C2CD00A7AF91 /* String+getDateString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+getDateString.swift"; sourceTree = "<group>"; };
+		491EF26827A7C31000A7AF91 /* UIImageView+downloadImageFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+downloadImageFrom.swift"; sourceTree = "<group>"; };
+		49245C4627A3D5C50059DF55 /* MainDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDataModel.swift; sourceTree = "<group>"; };
 		492C62182794F90500AE546E /* LoginNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginNavigationController.swift; sourceTree = "<group>"; };
 		492C621A279531F200AE546E /* AccountEditCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountEditCoordinator.swift; sourceTree = "<group>"; };
 		492C621C2795320C00AE546E /* PlayerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCoordinator.swift; sourceTree = "<group>"; };
@@ -139,6 +147,8 @@
 		49B9C9F1277AF018006AE134 /* UIFont+CustomFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+CustomFont.swift"; sourceTree = "<group>"; };
 		49C52CDE278B4379009D6FBB /* ChannelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelViewController.swift; sourceTree = "<group>"; };
 		49C52CDF278B4379009D6FBB /* Channel.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Channel.storyboard; sourceTree = "<group>"; };
+		49C6CF9E27A3DAAD007C2895 /* MainServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainServiceAPI.swift; sourceTree = "<group>"; };
+		49C6CFA127A3E080007C2895 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		49D7A0A92783DBB9001CAC60 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		49D7A0AB2783ECAD001CAC60 /* AppUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtility.swift; sourceTree = "<group>"; };
 		49D7A0AD27840595001CAC60 /* Register.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Register.storyboard; sourceTree = "<group>"; };
@@ -243,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				4935FD3C277BDC6600760675 /* Home.storyboard */,
+				49C6CFA127A3E080007C2895 /* HomeViewModel.swift */,
 				49E6BE30279100BC000E475C /* HomeNavigationController.swift */,
 				4935FD2E277BD95200760675 /* HomeListViewController.swift */,
 				4935FD30277BD97400760675 /* CategoryCell.swift */,
@@ -346,6 +357,8 @@
 		49B9C9F3277AF0E5006AE134 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				491EF26827A7C31000A7AF91 /* UIImageView+downloadImageFrom.swift */,
+				491EF26627A7C2CD00A7AF91 /* String+getDateString.swift */,
 				49E72FFD27A265D200DFBCC3 /* UITablewView+ScrollToBottom.swift */,
 				492C622F2795989F00AE546E /* CustomSlider.swift */,
 				490770A22797EA7A00ADD8E8 /* KeyChainWrapper+Key.swift */,
@@ -367,6 +380,15 @@
 				49C52CDE278B4379009D6FBB /* ChannelViewController.swift */,
 			);
 			path = Channel;
+			sourceTree = "<group>";
+		};
+		49C6CFA027A3DABA007C2895 /* MainService */ = {
+			isa = PBXGroup;
+			children = (
+				49C6CF9E27A3DAAD007C2895 /* MainServiceAPI.swift */,
+				49245C4627A3D5C50059DF55 /* MainDataModel.swift */,
+			);
+			path = MainService;
 			sourceTree = "<group>";
 		};
 		49D7A0A62783D730001CAC60 /* Register */ = {
@@ -430,6 +452,7 @@
 			isa = PBXGroup;
 			children = (
 				49E72FFA27A256FA00DFBCC3 /* UserService */,
+				49C6CFA027A3DABA007C2895 /* MainService */,
 				49E72FFB27A2570200DFBCC3 /* ChatService */,
 				49E72FD027A166E300DFBCC3 /* GatewayManager.swift */,
 				490770A42797F7A300ADD8E8 /* ErrorCodeConverter.swift */,
@@ -626,12 +649,14 @@
 			files = (
 				496279DE2782BB85005A2BDC /* AccountEditViewController.swift in Sources */,
 				49F0213E2799505400684A25 /* UIViewController+SimpleAlert.swift in Sources */,
+				491EF26927A7C31000A7AF91 /* UIImageView+downloadImageFrom.swift in Sources */,
 				496279DA278297C2005A2BDC /* VideoListViewController.swift in Sources */,
 				49D7A0AA2783DBB9001CAC60 /* LoginViewController.swift in Sources */,
 				49F18C52278F0FB100EBDCF8 /* UITabBarController+Visibility.swift in Sources */,
 				49E8E89E278BB5B0003AD1DF /* CameraView.swift in Sources */,
 				49D7A0B927840595001CAC60 /* RegisterNavigationController.swift in Sources */,
 				496279D627828BB3005A2BDC /* PlayExplainViewController.swift in Sources */,
+				491EF26727A7C2CE00A7AF91 /* String+getDateString.swift in Sources */,
 				49E72FD127A166E300DFBCC3 /* GatewayManager.swift in Sources */,
 				49D7A0B727840595001CAC60 /* IdInputViewController.swift in Sources */,
 				4935FD44277C0ED100760675 /* ChatCell.swift in Sources */,
@@ -648,12 +673,14 @@
 				49E8E899278BB4C2003AD1DF /* HorizontalVideoListCell.swift in Sources */,
 				492C6232279598CF00AE546E /* AVPlayer+isPlayer.swift in Sources */,
 				49EC99FD2782015A00DE4F79 /* RecentViewedCell.swift in Sources */,
+				49245C4727A3D5C50059DF55 /* MainDataModel.swift in Sources */,
 				492C62302795989F00AE546E /* CustomSlider.swift in Sources */,
 				496279D827829516005A2BDC /* MyPageNavigationController.swift in Sources */,
 				49E6BE3E2791A7C1000E475C /* SearchViewController.swift in Sources */,
 				49B9C9BA277ACE9C006AE134 /* AppDelegate.swift in Sources */,
 				49E6BE31279100BC000E475C /* HomeNavigationController.swift in Sources */,
 				49818AC52780C63F00C0C956 /* MyPageViewController.swift in Sources */,
+				49C6CF9F27A3DAAD007C2895 /* MainServiceAPI.swift in Sources */,
 				4935FD42277C0E4D00760675 /* ChattingViewController.swift in Sources */,
 				49E72FD327A168C600DFBCC3 /* ChatServiceAPI.swift in Sources */,
 				49EA4E0E279461B200A038E3 /* Coordinator.swift in Sources */,
@@ -673,6 +700,7 @@
 				492C621B279531F200AE546E /* AccountEditCoordinator.swift in Sources */,
 				49F18C54278F2EED00EBDCF8 /* PlayViewController.swift in Sources */,
 				49D7A0B627840595001CAC60 /* NickNameInputViewController.swift in Sources */,
+				49C6CFA227A3E080007C2895 /* HomeViewModel.swift in Sources */,
 				49B9C9F0277AEF4E006AE134 /* UIColor+CustomColor.swift in Sources */,
 				49E72FFE27A265D200DFBCC3 /* UITablewView+ScrollToBottom.swift in Sources */,
 				492C621F2795322300AE546E /* MyTabCoordinator.swift in Sources */,

--- a/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
+++ b/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		49F18C2C278E5E0800EBDCF8 /* CreateNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F18C2B278E5E0800EBDCF8 /* CreateNavigationController.swift */; };
 		49F18C52278F0FB100EBDCF8 /* UITabBarController+Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F18C51278F0FB100EBDCF8 /* UITabBarController+Visibility.swift */; };
 		49F18C54278F2EED00EBDCF8 /* PlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F18C53278F2EED00EBDCF8 /* PlayViewController.swift */; };
+		49F777D927AA58B800AD2D78 /* FriendRequestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F777D827AA58B800AD2D78 /* FriendRequestViewController.swift */; };
 		B86390ACC07320C4661BD124 /* Pods_PlayGround.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C094C2C5DF13CB2E6DBF8A02 /* Pods_PlayGround.framework */; };
 /* End PBXBuildFile section */
 
@@ -185,6 +186,7 @@
 		49F18C2B278E5E0800EBDCF8 /* CreateNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNavigationController.swift; sourceTree = "<group>"; };
 		49F18C51278F0FB100EBDCF8 /* UITabBarController+Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Visibility.swift"; sourceTree = "<group>"; };
 		49F18C53278F2EED00EBDCF8 /* PlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayViewController.swift; sourceTree = "<group>"; };
+		49F777D827AA58B800AD2D78 /* FriendRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestViewController.swift; sourceTree = "<group>"; };
 		8A3D7763AEF5C85EA43F3126 /* Pods-PlayGround.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PlayGround.debug.xcconfig"; path = "Target Support Files/Pods-PlayGround/Pods-PlayGround.debug.xcconfig"; sourceTree = "<group>"; };
 		C094C2C5DF13CB2E6DBF8A02 /* Pods_PlayGround.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PlayGround.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD5FDC1E3E6EC365A13644FD /* Pods-PlayGround.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PlayGround.release.xcconfig"; path = "Target Support Files/Pods-PlayGround/Pods-PlayGround.release.xcconfig"; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 			isa = PBXGroup;
 			children = (
 				49A308A12791AD72005D6109 /* Notice.storyboard */,
+				49F777D827AA58B800AD2D78 /* FriendRequestViewController.swift */,
 				49AC95292791AC080030DCC0 /* NoticeListViewController.swift */,
 			);
 			path = Notice;
@@ -694,6 +697,7 @@
 				49E72FF527A23F8C00DFBCC3 /* ChatViewModel.swift in Sources */,
 				49EC9A022782033E00DE4F79 /* CreatePopOverViewController.swift in Sources */,
 				492C62232795325000AE546E /* HomeTabCoordinator.swift in Sources */,
+				49F777D927AA58B800AD2D78 /* FriendRequestViewController.swift in Sources */,
 				492C622E27955F6C00AE546E /* Player.swift in Sources */,
 				49EC9A06278205D200DE4F79 /* UIView+RoundCorners.swift in Sources */,
 				490770A52797F7A300ADD8E8 /* ErrorCodeConverter.swift in Sources */,

--- a/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
+++ b/src/ios/PlayGround/PlayGround.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		49E8E89C278BB528003AD1DF /* Broadcast.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49E8E89B278BB528003AD1DF /* Broadcast.storyboard */; };
 		49E8E89E278BB5B0003AD1DF /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8E89D278BB5B0003AD1DF /* CameraView.swift */; };
 		49E8E8A0278BC264003AD1DF /* LiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8E89F278BC264003AD1DF /* LiveViewController.swift */; };
+		49E8F64027A962B900E030F6 /* PlayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8F63F27A962B900E030F6 /* PlayViewModel.swift */; };
 		49EA4E0E279461B200A038E3 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA4E0D279461B200A038E3 /* Coordinator.swift */; };
 		49EC99FD2782015A00DE4F79 /* RecentViewedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EC99FC2782015A00DE4F79 /* RecentViewedCell.swift */; };
 		49EC9A00278201C600DE4F79 /* Create.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49EC99FF278201C600DE4F79 /* Create.storyboard */; };
@@ -173,6 +174,7 @@
 		49E8E89B278BB528003AD1DF /* Broadcast.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Broadcast.storyboard; sourceTree = "<group>"; };
 		49E8E89D278BB5B0003AD1DF /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		49E8E89F278BC264003AD1DF /* LiveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveViewController.swift; sourceTree = "<group>"; };
+		49E8F63F27A962B900E030F6 /* PlayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayViewModel.swift; sourceTree = "<group>"; };
 		49EA4E0D279461B200A038E3 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		49EC99FC2782015A00DE4F79 /* RecentViewedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentViewedCell.swift; sourceTree = "<group>"; };
 		49EC99FF278201C600DE4F79 /* Create.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Create.storyboard; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 			isa = PBXGroup;
 			children = (
 				4935FD34277BD97F00760675 /* Play.storyboard */,
+				49E8F63F27A962B900E030F6 /* PlayViewModel.swift */,
 				49F18C53278F2EED00EBDCF8 /* PlayViewController.swift */,
 				496279D527828BB3005A2BDC /* PlayExplainViewController.swift */,
 				492C622D27955F6C00AE546E /* Player.swift */,
@@ -699,6 +702,7 @@
 				492C62212795323700AE546E /* CreateTabCoordinator.swift in Sources */,
 				492C621B279531F200AE546E /* AccountEditCoordinator.swift in Sources */,
 				49F18C54278F2EED00EBDCF8 /* PlayViewController.swift in Sources */,
+				49E8F64027A962B900E030F6 /* PlayViewModel.swift in Sources */,
 				49D7A0B627840595001CAC60 /* NickNameInputViewController.swift in Sources */,
 				49C6CFA227A3E080007C2895 /* HomeViewModel.swift in Sources */,
 				49B9C9F0277AEF4E006AE134 /* UIColor+CustomColor.swift in Sources */,

--- a/src/ios/PlayGround/PlayGround/Network/ChatService/ChatServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/ChatService/ChatServiceAPI.swift
@@ -12,7 +12,7 @@ class ChatServiceAPI {
     static let shared = ChatServiceAPI()
     var socketClient = StompClientLib()
     
-    let chatServiceUrl = "ws://localhost:8888/ws/websocket"
+    let chatServiceUrl = "ws://3.34.152.141:8888/ws/websocket"
     
     func connectToSocket(viewModel: ChatViewModel) {
         let url = NSURL(string: chatServiceUrl)!

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
@@ -46,3 +46,43 @@ struct GeneralVideo: Codable {
         case chatRoomId
     }
 }
+
+enum Action: String {
+    case Like = "LIKE"
+    case Dislike = "DISLIKE"
+    case Report = "REPORT"
+}
+
+struct Notice: Codable {
+    let notiType: String
+    let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case notiType
+        case content
+    }
+}
+
+struct Friend: Codable {
+    let nickname: String
+    let profileImage: String
+    let uuid: String
+    
+    enum CodingKeys: String, CodingKey {
+        case nickname
+        case profileImage
+        case uuid
+    }
+}
+
+struct FriendRequest: Codable {
+    let uuid: String
+    let nickname: String
+    let profileImage: String
+    
+    enum CodingKeys: String, CodingKey {
+        case uuid
+        case nickname
+        case profileImage
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
@@ -86,3 +86,13 @@ struct FriendRequest: Codable {
         case profileImage
     }
 }
+
+struct WatchingInfo: Codable {
+    let roomId: String
+    let title: String
+    
+    enum CodingKeys: String, CodingKey {
+        case roomId
+        case title
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
@@ -19,62 +19,6 @@ struct HomeList: Codable {
     }
 }
 
-enum Category: String {
-    case ALL = "전체"
-    case EDU = "교육"
-    case SPORTS = "스포츠"
-    case KPOP = "K-POP"
-}
-
-
-struct LiveRoom: Codable {
-    let id: Int
-    let title: String
-    let hostNickname: String
-    let fileLink: String?
-    let thumbnail: String
-    let category: String
-    let createdAt: String
-    let streamingId: String?
-    let chatRoomId: String?
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case hostNickname
-        case fileLink
-        case thumbnail
-        case category
-        case createdAt
-        case streamingId
-        case chatRoomId
-    }
-}
-
-
-struct Video: Codable {
-    let id: Int
-    let title: String
-    let uploaderNickname: String
-    let hits: Int
-    let fileLink: String?
-    let thumbnail: String
-    let category: String
-    let createdAt: String
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case uploaderNickname
-        case hits
-        case fileLink
-        case thumbnail
-        case category
-        case createdAt
-    }
-}
-
-
 struct GeneralVideo: Codable {
     let id: Int
     let title: String

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainDataModel.swift
@@ -1,0 +1,104 @@
+//
+//  MainDataModel.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/01/28.
+//
+
+import Foundation
+
+struct HomeList: Codable {
+    let liveRooms: [GeneralVideo]
+    let videos: [GeneralVideo]
+    let categories: [String]
+    
+    enum CodingKeys: String, CodingKey {
+        case liveRooms
+        case videos
+        case categories
+    }
+}
+
+enum Category: String {
+    case ALL = "전체"
+    case EDU = "교육"
+    case SPORTS = "스포츠"
+    case KPOP = "K-POP"
+}
+
+
+struct LiveRoom: Codable {
+    let id: Int
+    let title: String
+    let hostNickname: String
+    let fileLink: String?
+    let thumbnail: String
+    let category: String
+    let createdAt: String
+    let streamingId: String?
+    let chatRoomId: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case hostNickname
+        case fileLink
+        case thumbnail
+        case category
+        case createdAt
+        case streamingId
+        case chatRoomId
+    }
+}
+
+
+struct Video: Codable {
+    let id: Int
+    let title: String
+    let uploaderNickname: String
+    let hits: Int
+    let fileLink: String?
+    let thumbnail: String
+    let category: String
+    let createdAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case uploaderNickname
+        case hits
+        case fileLink
+        case thumbnail
+        case category
+        case createdAt
+    }
+}
+
+
+struct GeneralVideo: Codable {
+    let id: Int
+    let title: String
+    let hostNickname: String?
+    let uploaderNickname: String?
+    let fileLink: String?
+    let thumbnail: String
+    let hits: Int?
+    let category: String
+    let createdAt: String
+    let streamingId: String?
+    let chatRoomId: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case hostNickname
+        case uploaderNickname
+        case fileLink
+        case hits
+        case thumbnail
+        case category
+        case createdAt
+        case streamingId
+        case chatRoomId
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
@@ -14,7 +14,8 @@ struct MainServiceAPI {
     let mainServiceUrl = "http://\(GatewayManager.shared.gatewayAddress)/main-service"
     
     func getAllList(lastVideoId: Int, lastLiveId: Int, category: String, completion: @escaping ([String: Any])->Void) {
-        let original = "\(mainServiceUrl)/list?last-video=\(lastVideoId)&last-live=\(lastLiveId)&size=5&category=\(category)"
+        // infinite scroll 테스트를 위해 size 2로 설정
+        let original = "\(mainServiceUrl)/list?last-video=\(lastVideoId)&last-live=\(lastLiveId)&size=2&category=\(category)"
         
         guard let target = original.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             print("error encoding")

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
@@ -1,0 +1,51 @@
+//
+//  MainServiceAPI.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/01/28.
+//
+
+import Foundation
+import UIKit
+
+struct MainServiceAPI {
+    static let shared = MainServiceAPI()
+    
+    let mainServiceUrl = "http://\(GatewayManager.shared.gatewayAddress)/main-service"
+    
+    func getAllList(lastVideoId: Int, lastLiveId: Int, category: String, completion: @escaping ([String: Any])->Void) {
+        let original = "\(mainServiceUrl)/list?last-video=\(lastVideoId)&last-live=\(lastLiveId)&size=5&category=\(category)"
+        
+        guard let target = original.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            print("error encoding")
+            return
+        }
+        
+        let session = URLSession(configuration: .ephemeral)
+        let urlComponents = URLComponents(string: target)!
+        let requestURL = urlComponents.url!
+        let task = session.dataTask(with: requestURL) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
+                completion(["result" : 0])
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .millisecondsSince1970
+                let response = try decoder.decode(HomeList.self, from: resultData)
+                completion(["result": 1, "data": response])
+            } catch let error {
+                print("---> error while loading home list: \(error.localizedDescription)")
+                let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+                if let result = responseJSON as? [String: Any] {
+                    completion(result)
+                } else {
+                    completion(["result" : 0])
+                }
+            }
+        }
+        task.resume()
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
@@ -50,7 +50,7 @@ struct MainServiceAPI {
         task.resume()
     }
     
-    func tapButtons(videoId: String, type: Int, action: Action, uuid: String, completion: @escaping ([String: Any])->Void) {
+    func tapButtons(videoId: Int, type: Int, action: Action, uuid: String, completion: @escaping ([String: Any])->Void) {
         let url = URL(string: "\(mainServiceUrl)/action")!
         var request = URLRequest(url: url)
         let postData : [String: Any] = ["id": videoId, "type" : type, "action": action.rawValue, "uuid": uuid]

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
@@ -36,13 +36,14 @@ struct MainServiceAPI {
                 decoder.dateDecodingStrategy = .millisecondsSince1970
                 let response = try decoder.decode(HomeList.self, from: resultData)
                 completion(["result": 1, "data": response])
+                completion(["result": "success", "data": response])
             } catch let error {
                 print("---> error while loading home list: \(error.localizedDescription)")
                 let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
                 if let result = responseJSON as? [String: Any] {
                     completion(result)
                 } else {
-                    completion(["result" : 0])
+                    completion(["result": "failed"])
                 }
             }
         }

--- a/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
+++ b/src/ios/PlayGround/PlayGround/Network/MainService/MainServiceAPI.swift
@@ -28,14 +28,13 @@ struct MainServiceAPI {
             let successRange = 200 ..< 300
             guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
                 print("\(error?.localizedDescription ?? "no error") \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
-                completion(["result" : 0])
+                completion(["result": "failed"])
                 return
             }
             do {
                 let decoder = JSONDecoder()
                 decoder.dateDecodingStrategy = .millisecondsSince1970
                 let response = try decoder.decode(HomeList.self, from: resultData)
-                completion(["result": 1, "data": response])
                 completion(["result": "success", "data": response])
             } catch let error {
                 print("---> error while loading home list: \(error.localizedDescription)")
@@ -45,6 +44,270 @@ struct MainServiceAPI {
                 } else {
                     completion(["result": "failed"])
                 }
+            }
+        }
+        task.resume()
+    }
+    
+    func tapButtons(videoId: String, type: Int, action: Action, uuid: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/action")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["id": videoId, "type" : type, "action": action.rawValue, "uuid": uuid]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "POST"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
+            }
+        }
+        task.resume()
+    }
+    
+    func cancelButtons(videoId: String, type: Int, action: String, uuid: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/action")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["id": videoId, "type" : type, "action": action, "uuid": uuid]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "DELETE"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
+            }
+        }
+        task.resume()
+    }
+    
+    func loadNotifications(uuid: String, completion: @escaping ([String: Any])->Void) {
+        let original = "\(mainServiceUrl)/notification/\(uuid)"
+        
+        guard let target = original.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            print("error encoding")
+            return
+        }
+        
+        let session = URLSession(configuration: .ephemeral)
+        let urlComponents = URLComponents(string: target)!
+        let requestURL = urlComponents.url!
+        let task = session.dataTask(with: requestURL) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
+                completion(["result": "failed"])
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .millisecondsSince1970
+                let response = try decoder.decode(Notice.self, from: resultData)
+                completion(["result": "success", "data": response])
+            } catch let error {
+                print("---> error while loading notification: \(error.localizedDescription)")
+                let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+                if let result = responseJSON as? [String: Any] {
+                    completion(result)
+                } else {
+                    completion(["result": "failed"])
+                }
+            }
+        }
+        task.resume()
+    }
+    
+    func loadFriends(uuid: String, completion: @escaping ([String: Any])->Void) {
+        let original = "\(mainServiceUrl)/friends/\(uuid)"
+        
+        guard let target = original.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            print("error encoding")
+            return
+        }
+        
+        let session = URLSession(configuration: .ephemeral)
+        let urlComponents = URLComponents(string: target)!
+        let requestURL = urlComponents.url!
+        let task = session.dataTask(with: requestURL) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
+                completion(["result": "failed"])
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .millisecondsSince1970
+                let response = try decoder.decode(Friend.self, from: resultData)
+                completion(["result": "success", "data": response])
+            } catch let error {
+                print("---> error while loading friends: \(error.localizedDescription)")
+                let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+                if let result = responseJSON as? [String: Any] {
+                    completion(result)
+                } else {
+                    completion(["result": "failed"])
+                }
+            }
+        }
+        task.resume()
+    }
+    
+    func sendFriendRequest(uuid: String, target: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/friends/\(uuid)")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["target": target]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "POST"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
+            }
+        }
+        task.resume()
+    }
+    
+    func deleteFriend(uuid: String, target: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/friends/\(uuid)")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["target": target]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "DELETE"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
+            }
+        }
+        task.resume()
+    }
+    
+    func loadFriendRequests(uuid: String, completion: @escaping ([String: Any])->Void) {
+        let original = "\(mainServiceUrl)/friends/manage/\(uuid)"
+        
+        guard let target = original.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            print("error encoding")
+            return
+        }
+        
+        let session = URLSession(configuration: .ephemeral)
+        let urlComponents = URLComponents(string: target)!
+        let requestURL = urlComponents.url!
+        let task = session.dataTask(with: requestURL) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
+                completion(["result": "failed"])
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .millisecondsSince1970
+                let response = try decoder.decode(Friend.self, from: resultData)
+                completion(["result": "success", "data": response])
+            } catch let error {
+                print("---> error while loading friend requests: \(error.localizedDescription)")
+                let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+                if let result = responseJSON as? [String: Any] {
+                    completion(result)
+                } else {
+                    completion(["result": "failed"])
+                }
+            }
+        }
+        task.resume()
+    }
+    
+    func acceptFriendRequest(friendUUID: String, myUUID: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/friends/manage/\(friendUUID)")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["sender": myUUID]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "POST"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
+            }
+        }
+        task.resume()
+    }
+    
+    func deleteFriendRequest(friendUUID: String, myUUID: String, completion: @escaping ([String: Any])->Void) {
+        let url = URL(string: "\(mainServiceUrl)/friends/manage/\(friendUUID)")!
+        var request = URLRequest(url: url)
+        let postData : [String: Any] = ["sender": myUUID]
+        let jsonData = try? JSONSerialization.data(withJSONObject: postData)
+        request.httpMethod = "DELETE"
+        request.httpBody = jsonData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            let successRange = 200 ..< 300
+            guard error == nil, let statusCode = (response as? HTTPURLResponse)?.statusCode, successRange.contains(statusCode), let resultData = data else {
+                print("\(error?.localizedDescription ?? "no error") \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+                completion(["result": "failed"])
+                return
+            }
+            
+            let responseJSON = try? JSONSerialization.jsonObject(with: resultData, options: [])
+            if let result = responseJSON as? [String: Any] {
+                completion(result)
+            } else {
+                completion(["result": "failed"])
             }
         }
         task.resume()

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/Coordinator.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/Coordinator.swift
@@ -12,5 +12,5 @@ protocol Coordinator: AnyObject {
     var parentCoordinator: Coordinator? { get set }
     var childCoordinators: [Coordinator] { get set }
     var navigation: UINavigationController { get set }
-    func start()
+//    func start()
 }

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/HomeTabCoordinator.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/HomeTabCoordinator.swift
@@ -30,10 +30,10 @@ class HomeTabCoordinator: Coordinator {
         }
     }
     
-    func showPlayer() {
+    func showPlayer(info: GeneralVideo?) {
         let childCoordinator = PlayerCoordinator(parent: self.parentCoordinator, navigation: self.navigation)
         self.childCoordinators.append(childCoordinator)
-        childCoordinator.start()
+        childCoordinator.start(info: info)
     }
     
     func showSearch() {

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/MyTabCoordinator.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/MyTabCoordinator.swift
@@ -33,7 +33,7 @@ class MyTabCoordinator: Coordinator {
     func showPlayer() {
         let childCoordinator = PlayerCoordinator(parent: self.parentCoordinator, navigation: self.navigation)
         self.childCoordinators.append(childCoordinator)
-        childCoordinator.start()
+        childCoordinator.start(info: nil)
     }
     
     func showVideoList(index: Int) {

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/PlayerCoordinator.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/PlayerCoordinator.swift
@@ -26,6 +26,10 @@ class PlayerCoordinator: Coordinator {
                 vc is PlayViewController
             }) as? PlayViewController {
                 print("exist")
+                guard let currentInfo = playVC.viewModel.currentInfo, let newInfo = info else { return }
+                if currentInfo.id != newInfo.id {
+                    playVC.viewModel.currentInfo = info
+                }
                 playVC.isMinimized = false
                 mainVC.playViewTopMargin.constant = 0
                 mainVC.tabBarHeight.constant = 0
@@ -39,9 +43,9 @@ class PlayerCoordinator: Coordinator {
             } else {
                 print("new")
                 guard let playVC = UIStoryboard(name: "Play", bundle: nil).instantiateViewController(withIdentifier: "PlayViewController" ) as? PlayViewController else { return }
+                playVC.viewModel.currentInfo = info
                 playVC.coordinator = self
                 mainVC.addChild(playVC)
-                playVC.viewModel.currentInfo = info
                 mainVC.playContainerView.addSubview((playVC.view)!)
                 playVC.view.frame = mainVC.playContainerView.bounds
                 playVC.didMove(toParent: mainVC)

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/PlayerCoordinator.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Coordinator/PlayerCoordinator.swift
@@ -18,7 +18,7 @@ class PlayerCoordinator: Coordinator {
         self.parentCoordinator = parent
     }
 
-    func start() {
+    func start(info: GeneralVideo?) {
         DispatchQueue.main.async {
             guard let mainVC = self.parentCoordinator?.navigation.viewControllers.last as? CustomTabViewController else { return }
             mainVC.playContainerView.isHidden = false
@@ -41,6 +41,7 @@ class PlayerCoordinator: Coordinator {
                 guard let playVC = UIStoryboard(name: "Play", bundle: nil).instantiateViewController(withIdentifier: "PlayViewController" ) as? PlayViewController else { return }
                 playVC.coordinator = self
                 mainVC.addChild(playVC)
+                playVC.viewModel.currentInfo = info
                 mainVC.playContainerView.addSubview((playVC.view)!)
                 playVC.view.frame = mainVC.playContainerView.bounds
                 playVC.didMove(toParent: mainVC)
@@ -107,6 +108,7 @@ class PlayerCoordinator: Coordinator {
     
     func showExplain(vc: PlayViewController) {
         guard let explainVC = UIStoryboard(name: "Play", bundle: nil).instantiateViewController(withIdentifier: "PlayExplainViewController") as? PlayExplainViewController else { return }
+        explainVC.viewModel.currentInfo = vc.viewModel.currentInfo
         vc.addChild(explainVC)
         vc.explainContainerView.addSubview((explainVC.view)!)
         explainVC.view.frame = vc.explainContainerView.bounds

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Extensions/String+getDateString.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Extensions/String+getDateString.swift
@@ -1,0 +1,36 @@
+//
+//  String+getDateString.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/01/31.
+//
+
+import Foundation
+import UIKit
+
+
+extension String {
+    func getDateString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        guard let dateInfo = dateFormatter.date(from: self) else { return "정보 없음" }
+        dateFormatter.timeZone = TimeZone.current
+        let calendar = Calendar.current
+        let timeComponents = calendar.dateComponents([.hour, .minute, .day, .month, .year], from: dateInfo)
+        let nowComponents = calendar.dateComponents([.hour, .minute, .day, .month, .year], from: Date())
+        guard let differenceMin = calendar.dateComponents([.minute], from: timeComponents, to: nowComponents).minute, let differenceHour = calendar.dateComponents([.hour], from: timeComponents, to: nowComponents).hour, let differenceDay = calendar.dateComponents([.day], from: timeComponents, to: nowComponents).day, let differenceMonth = calendar.dateComponents([.month], from: timeComponents, to: nowComponents).month, let differenceYear = calendar.dateComponents([.year], from: timeComponents, to: nowComponents).year else { return "정보 없음" }
+        if differenceMin <= 60 {
+            return "\(differenceMin)분 전"
+        } else if differenceMin <= 1440 {
+            return "\(differenceHour)시간 전"
+        } else if differenceMonth <= 1 {
+            return "\(differenceDay)일 전"
+        } else if differenceYear <= 1 {
+            return "\(differenceMonth)개월 전"
+        } else {
+            return "\(differenceYear)년 전"
+        }
+    }
+}
+

--- a/src/ios/PlayGround/PlayGround/Presentation/Helper/Extensions/UIImageView+downloadImageFrom.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Helper/Extensions/UIImageView+downloadImageFrom.swift
@@ -1,0 +1,21 @@
+//
+//  UIImageView+downloadImageFrom.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/01/31.
+//
+
+import Foundation
+import UIKit
+
+extension UIImageView {
+    func downloadImageFrom(link: String, contentMode: UIView.ContentMode) {
+        URLSession.shared.dataTask(with: URL(string:link)!, completionHandler: {
+            (data, response, error) -> Void in
+            DispatchQueue.main.async {
+                self.contentMode =  contentMode
+                if let data = data { self.image = UIImage(data: data) }
+            }
+        }).resume()
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/CategoryCell.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/CategoryCell.swift
@@ -12,7 +12,7 @@ class CategoryCell: UICollectionViewCell {
     @IBOutlet weak var backView: UIView!
     @IBOutlet weak var categoryLabel: UILabel!
     
-    func setupUI(selected: Bool) {
+    func setupUI(selected: Bool, category: String) {
         if selected {
             backView.backgroundColor = UIColor.placeHolder
             backView.layer.borderColor = UIColor.placeHolder.cgColor
@@ -25,5 +25,6 @@ class CategoryCell: UICollectionViewCell {
         backView.layer.cornerRadius = 15
         backView.layer.borderWidth = 1
         categoryLabel.font = UIFont.Component
+        categoryLabel.text = category
     }
 }

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/Home.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/Home.storyboard
@@ -163,7 +163,7 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
                                                         </imageView>
                                                     </subviews>
-                                                    <color key="backgroundColor" name="Separator"/>
+                                                    <color key="backgroundColor" systemColor="labelColor"/>
                                                     <constraints>
                                                         <constraint firstItem="zpA-av-Vyq" firstAttribute="top" secondItem="J38-vs-nkq" secondAttribute="top" id="IXH-uU-Zj1"/>
                                                         <constraint firstAttribute="width" secondItem="J38-vs-nkq" secondAttribute="height" multiplier="16:9" priority="750" id="IaP-Ma-zCt"/>
@@ -314,6 +314,9 @@
         <namedColor name="YoutubeRed">
             <color red="0.92900002002716064" green="0.1289999932050705" blue="0.13699999451637268" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/Home.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/Home.storyboard
@@ -158,9 +158,18 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J38-vs-nkq">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zpA-av-Vyq">
+                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
+                                                        </imageView>
+                                                    </subviews>
                                                     <color key="backgroundColor" name="Separator"/>
                                                     <constraints>
+                                                        <constraint firstItem="zpA-av-Vyq" firstAttribute="top" secondItem="J38-vs-nkq" secondAttribute="top" id="IXH-uU-Zj1"/>
                                                         <constraint firstAttribute="width" secondItem="J38-vs-nkq" secondAttribute="height" multiplier="16:9" priority="750" id="IaP-Ma-zCt"/>
+                                                        <constraint firstItem="zpA-av-Vyq" firstAttribute="centerX" secondItem="J38-vs-nkq" secondAttribute="centerX" id="PAB-sZ-Y2t"/>
+                                                        <constraint firstItem="zpA-av-Vyq" firstAttribute="centerY" secondItem="J38-vs-nkq" secondAttribute="centerY" id="Pdh-pz-nkd"/>
+                                                        <constraint firstItem="zpA-av-Vyq" firstAttribute="leading" secondItem="J38-vs-nkq" secondAttribute="leading" id="d2q-pV-Etu"/>
                                                     </constraints>
                                                 </view>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="liveSign" translatesAutoresizingMaskIntoConstraints="NO" id="Suu-l4-YDW">
@@ -193,15 +202,6 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1명 시청 중" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxb-VC-CdG">
-                                                    <rect key="frame" x="102.5" y="272" width="75" height="14"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="14" id="Ff2-L1-Gb1"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fxJ-dR-lK1">
                                                     <rect key="frame" x="5" y="243" width="43" height="43"/>
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -211,7 +211,6 @@
                                                 </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="yxb-VC-CdG" firstAttribute="centerY" secondItem="3OY-zH-JXZ" secondAttribute="centerY" id="1MT-o4-7tw"/>
                                                 <constraint firstItem="rJb-gZ-83I" firstAttribute="top" secondItem="J38-vs-nkq" secondAttribute="bottom" constant="15" id="4hr-q8-9LF"/>
                                                 <constraint firstItem="fxJ-dR-lK1" firstAttribute="leading" secondItem="rJb-gZ-83I" secondAttribute="leading" constant="-5" id="68p-QE-6TE"/>
                                                 <constraint firstItem="fxJ-dR-lK1" firstAttribute="centerY" secondItem="rJb-gZ-83I" secondAttribute="centerY" id="CqD-eZ-J2K"/>
@@ -219,9 +218,9 @@
                                                 <constraint firstItem="J38-vs-nkq" firstAttribute="centerX" secondItem="bt1-6J-pBJ" secondAttribute="centerX" id="JW1-Mo-fKX"/>
                                                 <constraint firstItem="Suu-l4-YDW" firstAttribute="bottom" secondItem="J38-vs-nkq" secondAttribute="bottom" constant="-10" id="McM-9s-Azw"/>
                                                 <constraint firstItem="f45-AV-TzK" firstAttribute="top" secondItem="rJb-gZ-83I" secondAttribute="top" constant="-2" id="Oyc-gb-u5u"/>
+                                                <constraint firstAttribute="bottom" secondItem="3OY-zH-JXZ" secondAttribute="bottom" constant="23" id="PZe-n9-YKu"/>
                                                 <constraint firstItem="rJb-gZ-83I" firstAttribute="leading" secondItem="bt1-6J-pBJ" secondAttribute="leading" constant="10" id="YCs-jH-QiK"/>
                                                 <constraint firstItem="fxJ-dR-lK1" firstAttribute="top" secondItem="rJb-gZ-83I" secondAttribute="top" constant="-5" id="ZkL-ZN-PYA"/>
-                                                <constraint firstAttribute="bottom" secondItem="yxb-VC-CdG" secondAttribute="bottom" constant="23" id="bTE-pm-tdd"/>
                                                 <constraint firstItem="3OY-zH-JXZ" firstAttribute="top" secondItem="f45-AV-TzK" secondAttribute="bottom" constant="2" id="bqJ-Pu-cEz"/>
                                                 <constraint firstItem="Suu-l4-YDW" firstAttribute="trailing" secondItem="J38-vs-nkq" secondAttribute="trailing" constant="-10" id="dDF-J6-dZa"/>
                                                 <constraint firstAttribute="trailing" secondItem="f45-AV-TzK" secondAttribute="trailing" constant="15" id="dob-mr-RRe"/>
@@ -229,7 +228,6 @@
                                                 <constraint firstItem="3OY-zH-JXZ" firstAttribute="leading" secondItem="f45-AV-TzK" secondAttribute="leading" id="tGq-7v-1P5"/>
                                                 <constraint firstItem="J38-vs-nkq" firstAttribute="top" secondItem="bt1-6J-pBJ" secondAttribute="top" id="tsj-ep-gWn"/>
                                                 <constraint firstItem="fxJ-dR-lK1" firstAttribute="centerX" secondItem="rJb-gZ-83I" secondAttribute="centerX" id="zDL-VN-29S"/>
-                                                <constraint firstItem="yxb-VC-CdG" firstAttribute="leading" secondItem="3OY-zH-JXZ" secondAttribute="trailing" constant="3" id="zaZ-4M-bOW"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -237,8 +235,8 @@
                                             <outlet property="nicknameLabel" destination="3OY-zH-JXZ" id="J5h-HD-8EC"/>
                                             <outlet property="playView" destination="J38-vs-nkq" id="S6r-Wr-QtY"/>
                                             <outlet property="profileImageView" destination="rJb-gZ-83I" id="riT-JL-6sQ"/>
+                                            <outlet property="thumbnailImageView" destination="zpA-av-Vyq" id="0g9-ys-G7z"/>
                                             <outlet property="titleLabel" destination="f45-AV-TzK" id="SqY-Mc-aj7"/>
-                                            <outlet property="viewLabel" destination="yxb-VC-CdG" id="0zz-xk-Ugo"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
@@ -194,7 +194,7 @@ extension HomeListViewController: UITableViewDataSource, UITableViewDelegate {
             let width = UIScreen.main.bounds.width
             let height = width / 16 * 9
             playerView.frame = CGRect(x: cell?.frame.minX ?? 0, y: cell?.frame.minY ?? 0, width: width, height: height)
-            let url = URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!
+            guard let fileLink = viewModel.homeList[middleIndex].fileLink, let url = URL(string: fileLink) else { return }
             let avAsset = AVURLAsset(url: url)
             let item = AVPlayerItem(asset: avAsset)
             player.replaceCurrentItem(with: item)

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import AVFoundation
+import Combine
 
 class HomeListViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
@@ -15,14 +16,17 @@ class HomeListViewController: UIViewController {
     @IBOutlet weak var noticeButton: UIButton!
     @IBOutlet weak var friendButton: UIButton!
     @IBOutlet weak var collectionView: UICollectionView!
+    private var cancellable: Set<AnyCancellable> = []
     var selectedIndex = 0
-    
     let playerView = PlayerView()
     var safeTop: CGFloat = 0
     var safeBottom: CGFloat = 0
     var navVC: HomeNavigationController?
     var middle = 0
     var player = AVPlayer()
+    let viewModel = HomeViewModel()
+    
+    let categoryDic = ["ALL": "전체", "EDU": "교육", "SPORTS": "스포츠", "KPOP": "K-POP"]
     
     // MARK: - View Life Cycle
     override func viewDidLayoutSubviews() {
@@ -34,10 +38,12 @@ class HomeListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        bindViewModel()
         self.tableView.addSubview(playerView)
         self.playerView.isUserInteractionEnabled = false
         guard let nav = self.navigationController as? HomeNavigationController else{ return }
         self.navVC = nav
+        viewModel.loadAllList()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -50,6 +56,20 @@ class HomeListViewController: UIViewController {
         self.playerView.player?.pause()
         self.playerView.player?.replaceCurrentItem(with: nil)
         self.playerView.player = nil
+    }
+    
+    func bindViewModel() {
+        self.viewModel.$homeList.receive(on: DispatchQueue.main, options: nil)
+            .sink { [weak self] list in
+                guard let self = self else { return }
+                self.tableView.reloadData()
+                self.collectionView.reloadData()
+            }.store(in: &cancellable)
+        self.viewModel.$selectedCategory.receive(on: DispatchQueue.main, options: nil)
+            .sink { [weak self] selected in
+                guard let self = self else { return }
+                self.viewModel.loadAllList()
+            }.store(in: &cancellable)
     }
     
     func setupUI() {
@@ -85,39 +105,50 @@ class HomeListViewController: UIViewController {
 // MARK: - Category List (CollectionView)
 extension HomeListViewController: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return viewModel.categories.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CategoryCell", for: indexPath) as? CategoryCell else { return UICollectionViewCell() }
-        cell.setupUI(selected: selectedIndex == indexPath.item)
+        cell.setupUI(selected: selectedIndex == indexPath.item, category: categoryDic[viewModel.categories[indexPath.item]] ?? "기타")
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let item = "Label"
+        let item = categoryDic[viewModel.categories[indexPath.item]] ?? "기타"
         let itemSize = item.size(withAttributes: [
             NSAttributedString.Key.font : UIFont.Component
         ])
-        let width : CGFloat = itemSize.width + 30
+        let width : CGFloat = itemSize.width + 40
         return  CGSize(width: width, height: 30)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.selectedIndex = indexPath.item
+        self.viewModel.selectedCategory = viewModel.categories[indexPath.item]
+        self.viewModel.lastLiveId = -1
+        self.viewModel.lastVideoId = -1
+        self.tableView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
         self.collectionView.reloadData()
     }
 }
 
 // MARK: - Video List (TableView)
 extension HomeListViewController: UITableViewDataSource, UITableViewDelegate {
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return viewModel.homeList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "VideoListCell", for: indexPath) as? VideoListCell else { return UITableViewCell() }
-        cell.setupUI(indexPath.row, middle)
+        cell.setupUI(indexPath.row)
+        if let host = viewModel.homeList[indexPath.row].hostNickname, host != "" {
+            cell.setupLive(info: viewModel.homeList[indexPath.row])
+        } else {
+            cell.setupVideo(info: viewModel.homeList[indexPath.row])
+        }
+        
         cell.channelTapHandler = {
             self.playerView.player?.pause()
             self.playerView.player?.replaceCurrentItem(with: nil)
@@ -154,7 +185,8 @@ extension HomeListViewController: UITableViewDataSource, UITableViewDelegate {
             return
         }
         if scrollView == tableView {
-            let middleIndex = ((tableView.indexPathsForVisibleRows?.first?.row)! + (tableView.indexPathsForVisibleRows?.last?.row)!)/2
+            guard let visibleRows = tableView.indexPathsForVisibleRows, let first = visibleRows.first, let last = visibleRows.last else { return }
+            let middleIndex = ((first.row) + (last.row))/2
             if middle == middleIndex { return }
             self.middle = middleIndex
             self.playerView.player = nil

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeListViewController.swift
@@ -170,7 +170,7 @@ extension HomeListViewController: UITableViewDataSource, UITableViewDelegate {
         self.playerView.player?.pause()
         self.playerView.player?.replaceCurrentItem(with: nil)
         self.playerView.player = nil
-        self.navVC?.coordinator?.showPlayer()
+        self.navVC?.coordinator?.showPlayer(info: viewModel.homeList[indexPath.row])
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
@@ -16,17 +16,26 @@ class HomeViewModel {
 
     var lastLiveId = -1
     var lastVideoId = -1
+    var isLoading = false
+    var isFinished = false
     
     func loadAllList() {
+        isLoading = true
         MainServiceAPI.shared.getAllList(lastVideoId: lastVideoId, lastLiveId: lastLiveId, category: selectedCategory) { result in
             if result["result"] as? String == "success" {
                 guard let data = result["data"] as? HomeList else { return }
                 var addedList = data.liveRooms
                 addedList.append(contentsOf: data.videos)
-                self.homeList = addedList
+                if self.lastVideoId == -1 && self.lastLiveId == -1 {
+                    self.homeList = addedList
+                } else {
+                    self.homeList.append(contentsOf: addedList)
+                }
+                self.isFinished = (addedList.count == 0)
+                self.isLoading = false
                 self.categories = data.categories
-                self.lastLiveId = data.liveRooms.last?.id ?? -1
-                self.lastVideoId = data.videos.last?.id ?? -1
+                self.lastLiveId = data.liveRooms.last?.id ?? self.lastLiveId
+                self.lastVideoId = data.videos.last?.id ?? self.lastVideoId
             }
         }
     }

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  HomeViewModel.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/01/28.
+//
+
+import Foundation
+import UIKit
+import Combine
+
+class HomeViewModel {
+    @Published var homeList: [GeneralVideo] = []
+    @Published var selectedCategory = "ALL"
+    var categories: [String] = []
+
+    var lastLiveId = -1
+    var lastVideoId = -1
+    
+    func loadAllList() {
+        MainServiceAPI.shared.getAllList(lastVideoId: lastVideoId, lastLiveId: lastLiveId, category: selectedCategory) { result in
+            if result["result"] as? Int == 1 {
+                guard let data = result["data"] as? HomeList else { return }
+                var addedList = data.liveRooms
+                addedList.append(contentsOf: data.videos)
+                self.homeList = addedList
+                self.categories = data.categories
+                self.lastLiveId = data.liveRooms.last?.id ?? -1
+                self.lastVideoId = data.videos.last?.id ?? -1
+            }
+        }
+    }
+}

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/HomeViewModel.swift
@@ -19,7 +19,7 @@ class HomeViewModel {
     
     func loadAllList() {
         MainServiceAPI.shared.getAllList(lastVideoId: lastVideoId, lastLiveId: lastLiveId, category: selectedCategory) { result in
-            if result["result"] as? Int == 1 {
+            if result["result"] as? String == "success" {
                 guard let data = result["data"] as? HomeList else { return }
                 var addedList = data.liveRooms
                 addedList.append(contentsOf: data.videos)

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/VideoListCell.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Home/VideoListCell.swift
@@ -12,26 +12,33 @@ class VideoListCell: UITableViewCell {
     @IBOutlet weak var profileImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var nicknameLabel: UILabel!
-    @IBOutlet weak var viewLabel: UILabel!
     @IBOutlet weak var liveSign: UIImageView!
     @IBOutlet weak var playView: UIView!
+    @IBOutlet weak var thumbnailImageView: UIImageView!
     var channelTapHandler: (()->Void)?
     
-    func setupUI(_ index: Int, _ current: Int) {
+    func setupUI(_ index: Int) {
         titleLabel.font = UIFont.Component
-        titleLabel.text = "\(index)번째 동영상"
         nicknameLabel.font = UIFont.caption
         nicknameLabel.textColor = UIColor.customDarkGray
-        viewLabel.font = UIFont.caption
-        viewLabel.textColor = UIColor.customDarkGray
         profileImageView.layer.cornerRadius = 33 / 2
         profileImageView.backgroundColor = UIColor.placeHolder
         liveSign.layer.cornerRadius = 3
-//        if index == current {
-//            playView.player?.play()
-//        } else {
-//            playView.player?.pause()
-//        }
+    }
+    
+    func setupLive(info: GeneralVideo) {
+        titleLabel.text = info.title
+        nicknameLabel.text = info.hostNickname
+        liveSign.isHidden = false
+        thumbnailImageView.downloadImageFrom(link: info.thumbnail, contentMode: .scaleAspectFit)
+        nicknameLabel.text = "\(info.hostNickname ?? "익명") • \(info.createdAt.getDateString())"
+    }
+    
+    func setupVideo(info: GeneralVideo) {
+        titleLabel.text = info.title
+        nicknameLabel.text = "\(info.uploaderNickname ?? "익명") • 조회수 \(info.hits ?? 0)회 • \(info.createdAt.getDateString())"
+        liveSign.isHidden = true
+        thumbnailImageView.downloadImageFrom(link: info.thumbnail, contentMode: .scaleAspectFit)
     }
     
     @IBAction func channelProfileDidTap(_ sender: Any) {

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Notice/FriendRequestViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Notice/FriendRequestViewController.swift
@@ -1,18 +1,15 @@
 //
-//  NoticeListViewController.swift
+//  FriendRequestViewController.swift
 //  PlayGround
 //
-//  Created by chuiseo-MN on 2022/01/14.
+//  Created by chuiseo-MN on 2022/02/02.
 //
 
 import Foundation
 import UIKit
 
-class NoticeListViewController: UIViewController {
+class FriendRequestViewController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var friendRequestButton: UIButton!
-    @IBOutlet weak var friendRequestCountView: UIView!
-    @IBOutlet weak var friendRequestCountLabel: UILabel!
     var navVC: HomeNavigationController?
     
     override func viewDidLoad() {
@@ -24,21 +21,14 @@ class NoticeListViewController: UIViewController {
     
     func setupUI() {
         titleLabel.font = UIFont.SubTitle
-        friendRequestButton.layer.cornerRadius = 20
-        friendRequestCountView.layer.cornerRadius = 10
     }
     
     @IBAction func backButtonDidTap(_ sender: Any) {
         navVC?.coordinator?.pop()
     }
-    
-    @IBAction func friendRequestButtonDidTap(_ sender: Any) {
-        guard let vc = UIStoryboard(name: "Notice", bundle: nil).instantiateViewController(withIdentifier: "FriendRequestViewController") as? FriendRequestViewController else { return }
-        self.navVC?.pushViewController(vc, animated: true)
-    }
 }
 
-extension NoticeListViewController: UITableViewDataSource, UITableViewDelegate {
+extension FriendRequestViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 40
     }

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Notice/Notice.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Notice/Notice.storyboard
@@ -39,13 +39,13 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="알림" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IrC-6l-xoz">
-                                <rect key="frame" x="49" y="60.5" width="30" height="21"/>
+                                <rect key="frame" x="49" y="61" width="29.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="qvW-zS-Zfy">
-                                <rect key="frame" x="0.0" y="99" width="414" height="763"/>
+                                <rect key="frame" x="0.0" y="174" width="414" height="688"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="121" id="0dW-bv-qaq">
@@ -62,17 +62,64 @@
                                     <outlet property="delegate" destination="Y6W-OH-hqX" id="jwL-uP-zym"/>
                                 </connections>
                             </tableView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t8M-gC-iqE">
+                                <rect key="frame" x="25" y="114" width="364" height="40"/>
+                                <color key="backgroundColor" name="PGBlue"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="k2H-a6-Bgd"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain"/>
+                                <connections>
+                                    <action selector="friendRequestButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="rIZ-yg-C7g"/>
+                                </connections>
+                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Tn7-hY-0lE">
+                                <rect key="frame" x="162" y="124" width="90" height="20"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구 요청" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q2G-0o-fwE">
+                                        <rect key="frame" x="0.0" y="0.0" width="60" height="20"/>
+                                        <fontDescription key="fontDescription" name="AppleSDGothicNeo-Bold" family="Apple SD Gothic Neo" pointSize="16"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gNs-EU-Ho8">
+                                        <rect key="frame" x="70" y="0.0" width="20" height="20"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="oiV-r1-dHc">
+                                                <rect key="frame" x="0.0" y="1.5" width="20" height="19.5"/>
+                                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Bold" family="Apple SD Gothic Neo" pointSize="16"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" name="PGOrange"/>
+                                        <constraints>
+                                            <constraint firstItem="oiV-r1-dHc" firstAttribute="leading" secondItem="gNs-EU-Ho8" secondAttribute="leading" id="KdW-mg-kw7"/>
+                                            <constraint firstAttribute="width" constant="20" id="LaN-uW-2MX"/>
+                                            <constraint firstItem="oiV-r1-dHc" firstAttribute="centerY" secondItem="gNs-EU-Ho8" secondAttribute="centerY" constant="1" id="Y3P-nz-Omm"/>
+                                            <constraint firstAttribute="width" secondItem="gNs-EU-Ho8" secondAttribute="height" multiplier="1:1" id="tdU-eB-FIL"/>
+                                            <constraint firstItem="oiV-r1-dHc" firstAttribute="centerX" secondItem="gNs-EU-Ho8" secondAttribute="centerX" id="xZ2-9A-itS"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="bdp-FT-k5a" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="6Ao-ed-dAP"/>
+                            <constraint firstItem="t8M-gC-iqE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="25" id="Ld5-Rp-Wvd"/>
+                            <constraint firstItem="Tn7-hY-0lE" firstAttribute="centerY" secondItem="t8M-gC-iqE" secondAttribute="centerY" id="OEj-fp-26S"/>
                             <constraint firstItem="1b1-f2-BFE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="RBB-HN-2gh"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="qvW-zS-Zfy" secondAttribute="bottom" id="S57-9C-JhZ"/>
                             <constraint firstItem="IrC-6l-xoz" firstAttribute="leading" secondItem="bdp-FT-k5a" secondAttribute="trailing" constant="5" id="U7l-GM-BSp"/>
                             <constraint firstItem="1b1-f2-BFE" firstAttribute="top" secondItem="bdp-FT-k5a" secondAttribute="bottom" constant="15" id="UQh-Er-fPx"/>
+                            <constraint firstItem="t8M-gC-iqE" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="WRC-YP-vs2"/>
+                            <constraint firstItem="t8M-gC-iqE" firstAttribute="top" secondItem="1b1-f2-BFE" secondAttribute="bottom" constant="15" id="ctn-r7-dpp"/>
                             <constraint firstItem="bdp-FT-k5a" firstAttribute="width" secondItem="bdp-FT-k5a" secondAttribute="height" multiplier="1:1" id="djK-8L-6H1"/>
-                            <constraint firstItem="qvW-zS-Zfy" firstAttribute="top" secondItem="1b1-f2-BFE" secondAttribute="bottom" id="iKZ-dD-l0u"/>
+                            <constraint firstItem="Tn7-hY-0lE" firstAttribute="centerX" secondItem="t8M-gC-iqE" secondAttribute="centerX" id="dth-Tn-NVQ"/>
+                            <constraint firstItem="qvW-zS-Zfy" firstAttribute="top" secondItem="1b1-f2-BFE" secondAttribute="bottom" constant="75" id="iKZ-dD-l0u"/>
                             <constraint firstItem="bdp-FT-k5a" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="15" id="jik-6M-pIA"/>
                             <constraint firstItem="1b1-f2-BFE" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="le3-Oa-too"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="qvW-zS-Zfy" secondAttribute="trailing" id="qdw-7J-tre"/>
@@ -81,6 +128,9 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="friendRequestButton" destination="t8M-gC-iqE" id="Z2B-o0-zt0"/>
+                        <outlet property="friendRequestCountLabel" destination="oiV-r1-dHc" id="1ak-KP-NN6"/>
+                        <outlet property="friendRequestCountView" destination="gNs-EU-Ho8" id="GNP-5E-jzQ"/>
                         <outlet property="titleLabel" destination="IrC-6l-xoz" id="utk-ui-jdJ"/>
                     </connections>
                 </viewController>
@@ -88,9 +138,93 @@
             </objects>
             <point key="canvasLocation" x="131.8840579710145" y="65.625"/>
         </scene>
+        <!--Friend Request View Controller-->
+        <scene sceneID="sFT-3p-jxM">
+            <objects>
+                <viewController storyboardIdentifier="FriendRequestViewController" id="Xld-9E-CzE" customClass="FriendRequestViewController" customModule="PlayGround" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="PD2-ne-xgA">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XIL-7u-Yiy">
+                                <rect key="frame" x="20" y="59" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="24" id="Ha6-2y-J8R"/>
+                                    <constraint firstAttribute="width" secondItem="XIL-7u-Yiy" secondAttribute="height" multiplier="1:1" id="R9s-Fb-d0B"/>
+                                </constraints>
+                                <color key="tintColor" systemColor="labelColor"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" image="leftChevron_black"/>
+                                <connections>
+                                    <action selector="backButtonDidTap:" destination="Xld-9E-CzE" eventType="touchUpInside" id="Lfe-fx-V7U"/>
+                                </connections>
+                            </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dlJ-D0-QAQ">
+                                <rect key="frame" x="0.0" y="98" width="414" height="1"/>
+                                <color key="backgroundColor" name="Separator"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="hgx-2L-ldW"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구 요청" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ey7-9x-LGC">
+                                <rect key="frame" x="49" y="61" width="63.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="iyv-Cm-m4t">
+                                <rect key="frame" x="0.0" y="99" width="414" height="763"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="121" id="0lt-1l-u3T">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="121"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0lt-1l-u3T" id="bjC-lt-9Tt">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="121"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="Xld-9E-CzE" id="Njr-KJ-Bq0"/>
+                                    <outlet property="delegate" destination="Xld-9E-CzE" id="2iP-5X-aJn"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Z8t-CK-6Hw"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="XIL-7u-Yiy" firstAttribute="top" secondItem="Z8t-CK-6Hw" secondAttribute="top" constant="15" id="3ti-nf-Hyp"/>
+                            <constraint firstItem="Ey7-9x-LGC" firstAttribute="leading" secondItem="XIL-7u-Yiy" secondAttribute="trailing" constant="5" id="3v8-5c-FOy"/>
+                            <constraint firstItem="Ey7-9x-LGC" firstAttribute="centerY" secondItem="XIL-7u-Yiy" secondAttribute="centerY" id="6xz-bb-Szm"/>
+                            <constraint firstItem="iyv-Cm-m4t" firstAttribute="leading" secondItem="Z8t-CK-6Hw" secondAttribute="leading" id="9KK-Ls-KUI"/>
+                            <constraint firstItem="dlJ-D0-QAQ" firstAttribute="leading" secondItem="Z8t-CK-6Hw" secondAttribute="leading" id="CeF-9d-FYp"/>
+                            <constraint firstItem="Z8t-CK-6Hw" firstAttribute="bottom" secondItem="iyv-Cm-m4t" secondAttribute="bottom" id="FXG-qo-Xtd"/>
+                            <constraint firstItem="dlJ-D0-QAQ" firstAttribute="top" secondItem="XIL-7u-Yiy" secondAttribute="bottom" constant="15" id="N8v-Cp-pMB"/>
+                            <constraint firstItem="dlJ-D0-QAQ" firstAttribute="centerX" secondItem="Z8t-CK-6Hw" secondAttribute="centerX" id="QOE-eZ-PBx"/>
+                            <constraint firstItem="Z8t-CK-6Hw" firstAttribute="trailing" secondItem="iyv-Cm-m4t" secondAttribute="trailing" id="am5-n7-eQo"/>
+                            <constraint firstItem="iyv-Cm-m4t" firstAttribute="top" secondItem="dlJ-D0-QAQ" secondAttribute="bottom" id="tc6-6I-RZC"/>
+                            <constraint firstItem="XIL-7u-Yiy" firstAttribute="width" secondItem="XIL-7u-Yiy" secondAttribute="height" multiplier="1:1" id="z81-aS-Hck"/>
+                            <constraint firstItem="XIL-7u-Yiy" firstAttribute="leading" secondItem="Z8t-CK-6Hw" secondAttribute="leading" constant="20" id="zZO-pa-OjE"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="titleLabel" destination="Ey7-9x-LGC" id="fNv-Jf-icd"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xaX-eQ-eXD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="962" y="66"/>
+        </scene>
     </scenes>
     <resources>
         <image name="leftChevron_black" width="24" height="24"/>
+        <namedColor name="PGBlue">
+            <color red="0.25900000333786011" green="0.52499997615814209" blue="0.96100002527236938" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="PGOrange">
+            <color red="1" green="0.74099999666213989" blue="0.075000002980232239" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="Separator">
             <color red="0.89800000190734863" green="0.89800000190734863" blue="0.89800000190734863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/Search.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/Search.storyboard
@@ -56,95 +56,94 @@
                                 <rect key="frame" x="0.0" y="99" width="414" height="763"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="VideoListCell" rowHeight="309" id="Rdc-Cy-ecZ" customClass="VideoListCell" customModule="PlayGround" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="VideoListCell" rowHeight="309" id="GeP-TR-NZF" customClass="VideoListCell" customModule="PlayGround" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="44.5" width="414" height="309"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rdc-Cy-ecZ" id="22Z-MI-sld">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GeP-TR-NZF" id="9ND-Va-cNa">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="309"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvw-nP-axN">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="onT-FP-INk">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ay2-qO-KYR">
+                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="233"/>
+                                                        </imageView>
+                                                    </subviews>
                                                     <color key="backgroundColor" name="Separator"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" secondItem="Nvw-nP-axN" secondAttribute="height" multiplier="16:9" priority="750" id="aPE-KS-6vV"/>
+                                                        <constraint firstItem="Ay2-qO-KYR" firstAttribute="centerY" secondItem="onT-FP-INk" secondAttribute="centerY" id="4qF-rq-Wbm"/>
+                                                        <constraint firstItem="Ay2-qO-KYR" firstAttribute="centerX" secondItem="onT-FP-INk" secondAttribute="centerX" id="I2f-bD-Tmo"/>
+                                                        <constraint firstItem="Ay2-qO-KYR" firstAttribute="leading" secondItem="onT-FP-INk" secondAttribute="leading" id="Mii-dk-6Uo"/>
+                                                        <constraint firstItem="Ay2-qO-KYR" firstAttribute="top" secondItem="onT-FP-INk" secondAttribute="top" id="bRU-UY-yfp"/>
+                                                        <constraint firstAttribute="width" secondItem="onT-FP-INk" secondAttribute="height" multiplier="16:9" priority="750" id="h6m-MM-zbb"/>
                                                     </constraints>
                                                 </view>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="liveSign" translatesAutoresizingMaskIntoConstraints="NO" id="rTB-Ld-Fa0">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="liveSign" translatesAutoresizingMaskIntoConstraints="NO" id="cxz-qH-3aV">
                                                     <rect key="frame" x="350" y="205" width="54" height="18"/>
                                                     <color key="backgroundColor" name="YoutubeRed"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="54" id="0Jj-fB-C60"/>
-                                                        <constraint firstAttribute="height" constant="18" id="pxY-UY-RAm"/>
+                                                        <constraint firstAttribute="width" constant="54" id="8ED-4U-Vc3"/>
+                                                        <constraint firstAttribute="height" constant="18" id="OcX-JZ-LEy"/>
                                                     </constraints>
                                                 </imageView>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="shq-3S-68j">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fwL-kz-DOb">
                                                     <rect key="frame" x="10" y="248" width="33" height="33"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="33" id="eYS-sE-OEx"/>
-                                                        <constraint firstAttribute="width" secondItem="shq-3S-68j" secondAttribute="height" multiplier="1:1" id="rkJ-nR-daX"/>
+                                                        <constraint firstAttribute="width" constant="33" id="5G1-Cd-FOA"/>
+                                                        <constraint firstAttribute="width" secondItem="fwL-kz-DOb" secondAttribute="height" multiplier="1:1" id="ynq-uF-1Jd"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="영상 제목" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hkj-DG-Mbk">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="영상 제목" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f44-Zr-Phn">
                                                     <rect key="frame" x="55" y="246" width="344" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Bn-3p-BNq">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AfN-es-JrG">
                                                     <rect key="frame" x="55" y="272" width="44.5" height="14"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="14" id="iPY-ET-j4P"/>
+                                                        <constraint firstAttribute="height" constant="14" id="eZF-gq-nfq"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1명 시청 중" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sZA-zG-a0n">
-                                                    <rect key="frame" x="102.5" y="272" width="75" height="14"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="14" id="bvV-QY-nsV"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kNO-8O-Ilr">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nwA-9d-2P6">
                                                     <rect key="frame" x="5" y="243" width="43" height="43"/>
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     <connections>
-                                                        <action selector="channelProfileDidTap:" destination="Rdc-Cy-ecZ" eventType="touchUpInside" id="SNR-Fb-LGs"/>
+                                                        <action selector="channelProfileDidTap:" destination="GeP-TR-NZF" eventType="touchUpInside" id="BVo-6H-Iir"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="Nvw-nP-axN" firstAttribute="top" secondItem="22Z-MI-sld" secondAttribute="top" id="7OO-In-hxd"/>
-                                                <constraint firstItem="kNO-8O-Ilr" firstAttribute="top" secondItem="shq-3S-68j" secondAttribute="top" constant="-5" id="8Fb-Gh-Xia"/>
-                                                <constraint firstItem="3Bn-3p-BNq" firstAttribute="top" secondItem="Hkj-DG-Mbk" secondAttribute="bottom" constant="2" id="CQ6-VU-k0y"/>
-                                                <constraint firstItem="Hkj-DG-Mbk" firstAttribute="top" secondItem="shq-3S-68j" secondAttribute="top" constant="-2" id="Cih-Yj-Olz"/>
-                                                <constraint firstItem="kNO-8O-Ilr" firstAttribute="leading" secondItem="shq-3S-68j" secondAttribute="leading" constant="-5" id="GQA-Fb-cnC"/>
-                                                <constraint firstAttribute="bottom" secondItem="sZA-zG-a0n" secondAttribute="bottom" constant="23" id="Pl9-Ak-zgf"/>
-                                                <constraint firstItem="Nvw-nP-axN" firstAttribute="leading" secondItem="22Z-MI-sld" secondAttribute="leading" id="QX2-DO-oK4"/>
-                                                <constraint firstItem="shq-3S-68j" firstAttribute="top" secondItem="Nvw-nP-axN" secondAttribute="bottom" constant="15" id="Qmr-rc-oey"/>
-                                                <constraint firstItem="sZA-zG-a0n" firstAttribute="centerY" secondItem="3Bn-3p-BNq" secondAttribute="centerY" id="bja-an-Hiv"/>
-                                                <constraint firstItem="sZA-zG-a0n" firstAttribute="leading" secondItem="3Bn-3p-BNq" secondAttribute="trailing" constant="3" id="bw5-n3-Kxo"/>
-                                                <constraint firstItem="3Bn-3p-BNq" firstAttribute="leading" secondItem="Hkj-DG-Mbk" secondAttribute="leading" id="cxO-Vt-gwc"/>
-                                                <constraint firstItem="rTB-Ld-Fa0" firstAttribute="trailing" secondItem="Nvw-nP-axN" secondAttribute="trailing" constant="-10" id="gKu-WB-w3v"/>
-                                                <constraint firstItem="shq-3S-68j" firstAttribute="leading" secondItem="22Z-MI-sld" secondAttribute="leading" constant="10" id="kMj-Ul-vi8"/>
-                                                <constraint firstItem="kNO-8O-Ilr" firstAttribute="centerX" secondItem="shq-3S-68j" secondAttribute="centerX" id="rhi-SC-6q0"/>
-                                                <constraint firstItem="Hkj-DG-Mbk" firstAttribute="leading" secondItem="shq-3S-68j" secondAttribute="trailing" constant="12" id="rmr-jr-QK1"/>
-                                                <constraint firstItem="kNO-8O-Ilr" firstAttribute="centerY" secondItem="shq-3S-68j" secondAttribute="centerY" id="sRm-Af-Lhh"/>
-                                                <constraint firstItem="rTB-Ld-Fa0" firstAttribute="bottom" secondItem="Nvw-nP-axN" secondAttribute="bottom" constant="-10" id="usq-oS-FdY"/>
-                                                <constraint firstAttribute="trailing" secondItem="Hkj-DG-Mbk" secondAttribute="trailing" constant="15" id="uzj-YN-xJR"/>
-                                                <constraint firstItem="Nvw-nP-axN" firstAttribute="centerX" secondItem="22Z-MI-sld" secondAttribute="centerX" id="xjg-MS-kyz"/>
+                                                <constraint firstItem="cxz-qH-3aV" firstAttribute="bottom" secondItem="onT-FP-INk" secondAttribute="bottom" constant="-10" id="0M3-Kb-y5y"/>
+                                                <constraint firstItem="f44-Zr-Phn" firstAttribute="top" secondItem="fwL-kz-DOb" secondAttribute="top" constant="-2" id="0pk-NO-FyL"/>
+                                                <constraint firstItem="nwA-9d-2P6" firstAttribute="centerX" secondItem="fwL-kz-DOb" secondAttribute="centerX" id="35A-Mf-s14"/>
+                                                <constraint firstItem="f44-Zr-Phn" firstAttribute="leading" secondItem="fwL-kz-DOb" secondAttribute="trailing" constant="12" id="66L-JC-E0b"/>
+                                                <constraint firstItem="AfN-es-JrG" firstAttribute="top" secondItem="f44-Zr-Phn" secondAttribute="bottom" constant="2" id="9VX-lu-zdh"/>
+                                                <constraint firstAttribute="bottom" secondItem="AfN-es-JrG" secondAttribute="bottom" constant="23" id="DiT-q8-XWj"/>
+                                                <constraint firstItem="fwL-kz-DOb" firstAttribute="leading" secondItem="9ND-Va-cNa" secondAttribute="leading" constant="10" id="E1d-dR-1f5"/>
+                                                <constraint firstItem="AfN-es-JrG" firstAttribute="leading" secondItem="f44-Zr-Phn" secondAttribute="leading" id="PqX-54-rK4"/>
+                                                <constraint firstItem="fwL-kz-DOb" firstAttribute="top" secondItem="onT-FP-INk" secondAttribute="bottom" constant="15" id="QiP-lH-bx8"/>
+                                                <constraint firstItem="cxz-qH-3aV" firstAttribute="trailing" secondItem="onT-FP-INk" secondAttribute="trailing" constant="-10" id="XhD-Gj-xX0"/>
+                                                <constraint firstItem="onT-FP-INk" firstAttribute="leading" secondItem="9ND-Va-cNa" secondAttribute="leading" id="fs2-EO-Ahe"/>
+                                                <constraint firstItem="nwA-9d-2P6" firstAttribute="centerY" secondItem="fwL-kz-DOb" secondAttribute="centerY" id="iT2-hx-U0r"/>
+                                                <constraint firstAttribute="trailing" secondItem="f44-Zr-Phn" secondAttribute="trailing" constant="15" id="jQQ-Lb-LFB"/>
+                                                <constraint firstItem="nwA-9d-2P6" firstAttribute="leading" secondItem="fwL-kz-DOb" secondAttribute="leading" constant="-5" id="oHl-cM-kf3"/>
+                                                <constraint firstItem="onT-FP-INk" firstAttribute="centerX" secondItem="9ND-Va-cNa" secondAttribute="centerX" id="of3-vf-ylY"/>
+                                                <constraint firstItem="onT-FP-INk" firstAttribute="top" secondItem="9ND-Va-cNa" secondAttribute="top" id="tpT-QY-7Ql"/>
+                                                <constraint firstItem="nwA-9d-2P6" firstAttribute="top" secondItem="fwL-kz-DOb" secondAttribute="top" constant="-5" id="uam-eg-Zao"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="liveSign" destination="rTB-Ld-Fa0" id="oN0-hd-Ibc"/>
-                                            <outlet property="nicknameLabel" destination="3Bn-3p-BNq" id="GHK-Vc-17n"/>
-                                            <outlet property="profileImageView" destination="shq-3S-68j" id="TWm-mc-Qm8"/>
-                                            <outlet property="titleLabel" destination="Hkj-DG-Mbk" id="78z-6G-iCk"/>
-                                            <outlet property="viewLabel" destination="sZA-zG-a0n" id="A5F-8B-zxa"/>
+                                            <outlet property="liveSign" destination="cxz-qH-3aV" id="X3O-r5-9g1"/>
+                                            <outlet property="nicknameLabel" destination="AfN-es-JrG" id="FfX-9T-PWg"/>
+                                            <outlet property="playView" destination="onT-FP-INk" id="4cQ-Tk-rLT"/>
+                                            <outlet property="profileImageView" destination="fwL-kz-DOb" id="QBS-E6-BMP"/>
+                                            <outlet property="thumbnailImageView" destination="Ay2-qO-KYR" id="uXw-Nv-QKc"/>
+                                            <outlet property="titleLabel" destination="f44-Zr-Phn" id="Ocp-OR-TnQ"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/SearchViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/SearchViewController.swift
@@ -48,7 +48,7 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        navVC?.coordinator?.showPlayer()
+        navVC?.coordinator?.showPlayer(info: nil)
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/SearchViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/HomeTab/Search/SearchViewController.swift
@@ -40,7 +40,7 @@ extension SearchViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "VideoListCell", for: indexPath) as? VideoListCell else { return UITableViewCell() }
-        cell.setupUI(indexPath.row, 0)
+        cell.setupUI(indexPath.row)
         cell.channelTapHandler = {
             self.navVC?.coordinator?.showChannel()
         }

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Channel/ChannelViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Channel/ChannelViewController.swift
@@ -61,7 +61,7 @@ extension ChannelViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "VideoListCell", for: indexPath) as? VideoListCell else { return UITableViewCell() }
-        cell.setupUI(indexPath.row, 0)
+        cell.setupUI(indexPath.row)
         return cell
     }
     

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Channel/ChannelViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Channel/ChannelViewController.swift
@@ -67,7 +67,7 @@ extension ChannelViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let navVC = self.navigationController as? HomeNavigationController else{ return }
-        navVC.coordinator?.showPlayer()
+        navVC.coordinator?.showPlayer(info: nil)
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Chat/ChattingViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Chat/ChattingViewController.swift
@@ -23,7 +23,7 @@ class ChattingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // 추후에 실제 roomId로 변경
-        viewModel.roomId = "ae0a8eb9-ff2c-4256-8be7-f8a9e84a3afa"
+        viewModel.roomId = "05e354e8-61bd-4764-96f7-7ebb4ac845de"
         viewModel.connectToSocket()
         bingViewModelData()
         setupUI()

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
@@ -81,6 +81,10 @@
                                             <action selector="enlargeButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="gH1-Bq-3L0"/>
                                         </connections>
                                     </button>
+                                    <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="54a-iR-rci">
+                                        <rect key="frame" x="10" y="183" width="394" height="50"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </view>
                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="XbX-Kr-dZU" customClass="CustomSlider" customModule="PlayGround" customModuleProvider="target">
                                         <rect key="frame" x="18" y="193" width="378" height="31"/>
                                     </slider>
@@ -100,12 +104,16 @@
                                     <constraint firstItem="gdz-vP-Wa1" firstAttribute="centerY" secondItem="LRj-f8-gzh" secondAttribute="centerY" id="CFI-hS-E3t"/>
                                     <constraint firstAttribute="bottom" secondItem="XbX-Kr-dZU" secondAttribute="bottom" constant="10" id="TDD-l3-rHr"/>
                                     <constraint firstItem="XbX-Kr-dZU" firstAttribute="centerX" secondItem="LRj-f8-gzh" secondAttribute="centerX" priority="999" id="VRb-Se-rTX"/>
+                                    <constraint firstItem="54a-iR-rci" firstAttribute="top" secondItem="XbX-Kr-dZU" secondAttribute="top" constant="-10" id="Y9k-Px-KhA"/>
                                     <constraint firstItem="gdz-vP-Wa1" firstAttribute="centerX" secondItem="LRj-f8-gzh" secondAttribute="centerX" id="b8A-j3-pM2"/>
+                                    <constraint firstItem="54a-iR-rci" firstAttribute="leading" secondItem="XbX-Kr-dZU" secondAttribute="leading" constant="-10" id="d91-gW-fXn"/>
                                     <constraint firstItem="aOM-mK-z29" firstAttribute="top" secondItem="LRj-f8-gzh" secondAttribute="top" constant="15" id="ev1-28-OlK"/>
                                     <constraint firstItem="XbX-Kr-dZU" firstAttribute="leading" secondItem="LRj-f8-gzh" secondAttribute="leading" constant="20" id="iHH-1e-7QR"/>
                                     <constraint firstItem="aOM-mK-z29" firstAttribute="leading" secondItem="LRj-f8-gzh" secondAttribute="leading" constant="20" id="k4C-SX-Mr9"/>
                                     <constraint firstItem="zbm-Dr-h03" firstAttribute="width" secondItem="zbm-Dr-h03" secondAttribute="height" multiplier="1:1" id="lb3-9o-Ppt"/>
                                     <constraint firstAttribute="bottom" secondItem="zbm-Dr-h03" secondAttribute="bottom" constant="35" id="rha-rj-dce"/>
+                                    <constraint firstItem="54a-iR-rci" firstAttribute="centerX" secondItem="XbX-Kr-dZU" secondAttribute="centerX" id="s13-wy-aSm"/>
+                                    <constraint firstItem="54a-iR-rci" firstAttribute="centerY" secondItem="XbX-Kr-dZU" secondAttribute="centerY" id="trB-cH-Pn6"/>
                                     <constraint firstItem="XbX-Kr-dZU" firstAttribute="top" secondItem="CXv-Af-7tz" secondAttribute="bottom" constant="10" id="u1v-fS-vVT"/>
                                 </constraints>
                                 <connections>
@@ -132,20 +140,20 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zrS-u7-i04">
                                 <rect key="frame" x="0.0" y="277" width="414" height="133"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ub-wC-BPw">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ub-wC-BPw">
                                         <rect key="frame" x="20" y="12" width="344" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0명 시청 중" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYG-q8-tSZ">
-                                        <rect key="frame" x="20" y="37.5" width="78" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYG-q8-tSZ">
+                                        <rect key="frame" x="20" y="37.5" width="9" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#category" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfl-hl-5kP">
-                                        <rect key="frame" x="108" y="37.5" width="78" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hfl-hl-5kP">
+                                        <rect key="frame" x="39" y="37.5" width="9" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" name="YoutubeBlue"/>
                                         <nil key="highlightedColor"/>
@@ -348,8 +356,8 @@
                                             <constraint firstAttribute="width" constant="33" id="sMV-vi-hOi"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ke-YZ-YXI">
-                                        <rect key="frame" x="58" y="14.5" width="60" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ke-YZ-YXI">
+                                        <rect key="frame" x="58" y="14.5" width="9" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -566,6 +574,7 @@
                         <outlet property="safeBottomView" destination="9wx-Cn-ZFu" id="Yjc-CZ-c12"/>
                         <outlet property="safeBottomViewHeight" destination="zNw-w9-rtl" id="Jrh-Ql-hNF"/>
                         <outlet property="seekbar" destination="XbX-Kr-dZU" id="0Nw-Bg-kO5"/>
+                        <outlet property="seekbarBackView" destination="54a-iR-rci" id="4Z7-jD-x4K"/>
                         <outlet property="separatorView" destination="wpe-05-P7u" id="dQ7-EI-RxE"/>
                         <outlet property="stackView" destination="AsF-jZ-9Y1" id="mcp-4k-CRe"/>
                         <outlet property="stretchButton" destination="ckV-PD-W2u" id="73b-7c-0jy"/>

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
-        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -318,6 +317,18 @@
                                     <constraint firstAttribute="height" constant="1" id="PH4-uS-RwY"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ckV-PD-W2u">
+                                <rect key="frame" x="370" y="287" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="24" id="l4A-n0-9IJ"/>
+                                    <constraint firstAttribute="width" secondItem="ckV-PD-W2u" secondAttribute="height" multiplier="1:1" id="ob3-a1-Et7"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="chevronDown"/>
+                                <connections>
+                                    <action selector="explainStretchButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="2Uf-v2-p0x"/>
+                                </connections>
+                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u2M-AS-nkI">
                                 <rect key="frame" x="0.0" y="411" width="414" height="50"/>
                                 <subviews>
@@ -418,56 +429,24 @@
                                         <color key="textColor" name="PlaceHolder"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sed-9C-gDY">
-                                        <rect key="frame" x="52" y="56.5" width="20" height="14"/>
-                                        <color key="tintColor" name="PlaceHolder"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="sed-9C-gDY" secondAttribute="height" multiplier="1:1" id="9vx-Gt-znf"/>
-                                            <constraint firstAttribute="width" constant="20" id="Z4K-sc-UMJ"/>
-                                        </constraints>
-                                        <imageReference key="image" image="square" catalog="system" symbolScale="small"/>
-                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default" weight="light"/>
-                                    </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d0t-Vu-BJs">
-                                        <rect key="frame" x="42" y="56" width="112" height="15"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="15" id="dgx-UQ-MUj"/>
-                                        </constraints>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title=""/>
-                                    </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="채팅 상단 고정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rPt-Rb-93z">
-                                        <rect key="frame" x="75" y="56.5" width="69" height="14.5"/>
-                                        <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="12"/>
-                                        <color key="textColor" name="PlaceHolder"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="sed-9C-gDY" firstAttribute="centerY" secondItem="rPt-Rb-93z" secondAttribute="centerY" id="0FQ-gD-rqo"/>
                                     <constraint firstAttribute="trailing" secondItem="9ux-Rl-nYc" secondAttribute="trailing" constant="55" id="2V3-EY-L6H"/>
                                     <constraint firstItem="bU9-fQ-yjR" firstAttribute="leading" secondItem="9ux-Rl-nYc" secondAttribute="leading" id="2iR-eM-Gnh"/>
                                     <constraint firstAttribute="height" constant="80" id="4cw-lI-fks"/>
                                     <constraint firstItem="Qe2-mD-WFT" firstAttribute="width" secondItem="Qe2-mD-WFT" secondAttribute="height" multiplier="1:1" id="6T3-IO-jEU"/>
                                     <constraint firstItem="Qe2-mD-WFT" firstAttribute="leading" secondItem="SOH-HM-MYK" secondAttribute="leading" constant="20" id="7X5-nu-nrY"/>
-                                    <constraint firstItem="d0t-Vu-BJs" firstAttribute="leading" secondItem="sed-9C-gDY" secondAttribute="leading" constant="-10" id="8Ji-o1-EHk"/>
                                     <constraint firstItem="x3j-Zy-qi6" firstAttribute="top" secondItem="bU9-fQ-yjR" secondAttribute="bottom" constant="3" id="8ho-Nr-Wec"/>
                                     <constraint firstItem="vr5-XT-ZmG" firstAttribute="leading" secondItem="9ux-Rl-nYc" secondAttribute="leading" id="Er5-2W-Kfs"/>
                                     <constraint firstItem="bU7-JT-1nv" firstAttribute="leading" secondItem="SOH-HM-MYK" secondAttribute="leading" id="H9O-Qr-35X"/>
                                     <constraint firstItem="TGg-mc-7vl" firstAttribute="top" secondItem="SOH-HM-MYK" secondAttribute="top" constant="15" id="KYM-9f-tz6"/>
-                                    <constraint firstItem="d0t-Vu-BJs" firstAttribute="top" secondItem="bU9-fQ-yjR" secondAttribute="bottom" constant="5" id="UKL-qS-X1L"/>
                                     <constraint firstItem="bU7-JT-1nv" firstAttribute="centerX" secondItem="SOH-HM-MYK" secondAttribute="centerX" id="XFB-I2-Fmy"/>
-                                    <constraint firstItem="d0t-Vu-BJs" firstAttribute="centerY" secondItem="rPt-Rb-93z" secondAttribute="centerY" id="aN4-Np-gqO"/>
-                                    <constraint firstItem="rPt-Rb-93z" firstAttribute="leading" secondItem="sed-9C-gDY" secondAttribute="trailing" constant="3" id="b6k-L5-YEB"/>
                                     <constraint firstItem="Qe2-mD-WFT" firstAttribute="top" secondItem="SOH-HM-MYK" secondAttribute="top" constant="18" id="bML-Nb-mYA"/>
                                     <constraint firstItem="9ux-Rl-nYc" firstAttribute="top" secondItem="SOH-HM-MYK" secondAttribute="top" constant="15" id="fJm-ZB-A65"/>
-                                    <constraint firstItem="d0t-Vu-BJs" firstAttribute="trailing" secondItem="rPt-Rb-93z" secondAttribute="trailing" constant="10" id="fs7-79-Fss"/>
-                                    <constraint firstItem="sed-9C-gDY" firstAttribute="width" secondItem="sed-9C-gDY" secondAttribute="height" multiplier="1:1" id="hr2-Rb-eKj"/>
                                     <constraint firstItem="bU7-JT-1nv" firstAttribute="top" secondItem="SOH-HM-MYK" secondAttribute="top" id="jhp-yJ-8AB"/>
                                     <constraint firstItem="bU9-fQ-yjR" firstAttribute="centerX" secondItem="9ux-Rl-nYc" secondAttribute="centerX" id="jnN-BK-qFO"/>
                                     <constraint firstItem="9ux-Rl-nYc" firstAttribute="leading" secondItem="SOH-HM-MYK" secondAttribute="leading" constant="55" id="oet-FV-UqR"/>
-                                    <constraint firstItem="d0t-Vu-BJs" firstAttribute="leading" secondItem="bU9-fQ-yjR" secondAttribute="leading" constant="-13" id="pZ9-4i-2BW"/>
                                     <constraint firstItem="bU9-fQ-yjR" firstAttribute="top" secondItem="9ux-Rl-nYc" secondAttribute="bottom" id="pyc-vA-nBK"/>
                                     <constraint firstItem="vr5-XT-ZmG" firstAttribute="centerY" secondItem="Qe2-mD-WFT" secondAttribute="centerY" id="tcy-IF-W1L"/>
                                     <constraint firstItem="x3j-Zy-qi6" firstAttribute="trailing" secondItem="bU9-fQ-yjR" secondAttribute="trailing" id="yLw-sg-UvK"/>
@@ -481,18 +460,6 @@
                                     <constraint firstAttribute="height" constant="34" id="zNw-w9-rtl"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ckV-PD-W2u">
-                                <rect key="frame" x="370" y="287" width="24" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="24" id="l4A-n0-9IJ"/>
-                                    <constraint firstAttribute="width" secondItem="ckV-PD-W2u" secondAttribute="height" multiplier="1:1" id="ob3-a1-Et7"/>
-                                </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" image="chevronDown"/>
-                                <connections>
-                                    <action selector="explainStretchButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="2Uf-v2-p0x"/>
-                                </connections>
-                            </button>
                             <containerView opaque="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YG8-9c-nRp">
                                 <rect key="frame" x="0.0" y="277" width="414" height="585"/>
                                 <connections>
@@ -507,12 +474,12 @@
                             <constraint firstItem="z4m-dy-jqD" firstAttribute="width" secondItem="z4m-dy-jqD" secondAttribute="height" multiplier="1:1" id="0c4-hH-NwY"/>
                             <constraint firstItem="SOH-HM-MYK" firstAttribute="leading" secondItem="QMm-yw-Spv" secondAttribute="leading" priority="750" id="23X-W3-xWZ"/>
                             <constraint firstItem="zrS-u7-i04" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="27b-Bv-xfa"/>
+                            <constraint firstItem="O9k-78-gSx" firstAttribute="bottom" secondItem="YG8-9c-nRp" secondAttribute="bottom" id="6MQ-Kw-EnQ"/>
                             <constraint firstItem="O9k-78-gSx" firstAttribute="bottom" secondItem="QMm-yw-Spv" secondAttribute="bottom" constant="80" id="6X7-eR-foj"/>
                             <constraint firstItem="LRj-f8-gzh" firstAttribute="centerY" secondItem="yqi-XC-h5e" secondAttribute="centerY" id="6gJ-Gd-tGY"/>
                             <constraint firstItem="O9k-78-gSx" firstAttribute="leading" secondItem="yqi-XC-h5e" secondAttribute="leading" id="7gx-rw-Hk6"/>
                             <constraint firstItem="SOH-HM-MYK" firstAttribute="trailing" secondItem="QMm-yw-Spv" secondAttribute="trailing" id="8ta-Xe-gKw"/>
                             <constraint firstItem="zrS-u7-i04" firstAttribute="leading" secondItem="O9k-78-gSx" secondAttribute="leading" id="9Az-bb-gkG"/>
-                            <constraint firstItem="YG8-9c-nRp" firstAttribute="top" secondItem="yqi-XC-h5e" secondAttribute="bottom" id="BMP-qz-gRU"/>
                             <constraint firstItem="qkx-vn-sS9" firstAttribute="centerY" secondItem="yqi-XC-h5e" secondAttribute="centerY" id="BYR-47-HaI"/>
                             <constraint firstItem="wpe-05-P7u" firstAttribute="centerX" secondItem="cV8-tH-dwF" secondAttribute="centerX" id="Cop-Jt-R02"/>
                             <constraint firstItem="zrS-u7-i04" firstAttribute="top" secondItem="yqi-XC-h5e" secondAttribute="bottom" id="DpN-D7-Leq"/>
@@ -520,8 +487,8 @@
                             <constraint firstItem="QMm-yw-Spv" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="HMe-d4-Evq"/>
                             <constraint firstItem="QMm-yw-Spv" firstAttribute="top" secondItem="wpe-05-P7u" secondAttribute="bottom" priority="999" id="ONh-uJ-d8P"/>
                             <constraint firstItem="u2M-AS-nkI" firstAttribute="leading" secondItem="O9k-78-gSx" secondAttribute="leading" id="PvT-3s-vOT"/>
-                            <constraint firstItem="YG8-9c-nRp" firstAttribute="leading" secondItem="O9k-78-gSx" secondAttribute="leading" id="Q8r-7l-VEH"/>
                             <constraint firstItem="cV8-tH-dwF" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="QqS-cr-zqP"/>
+                            <constraint firstItem="YG8-9c-nRp" firstAttribute="leading" secondItem="O9k-78-gSx" secondAttribute="leading" id="Qwf-0Q-zPj"/>
                             <constraint firstItem="9wx-Cn-ZFu" firstAttribute="top" secondItem="SOH-HM-MYK" secondAttribute="bottom" id="RqR-Ff-OiT"/>
                             <constraint firstItem="yqi-XC-h5e" firstAttribute="top" secondItem="O9k-78-gSx" secondAttribute="top" priority="999" id="S62-GT-XAz"/>
                             <constraint firstItem="z4m-dy-jqD" firstAttribute="centerY" secondItem="yqi-XC-h5e" secondAttribute="centerY" id="SA2-5j-sob"/>
@@ -534,16 +501,16 @@
                             <constraint firstItem="LRj-f8-gzh" firstAttribute="leading" secondItem="yqi-XC-h5e" secondAttribute="leading" id="YuO-TV-3ZY"/>
                             <constraint firstItem="yqi-XC-h5e" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" priority="750" id="ZZ4-Fk-jH1"/>
                             <constraint firstItem="LRj-f8-gzh" firstAttribute="centerX" secondItem="yqi-XC-h5e" secondAttribute="centerX" id="f8w-oc-jN1"/>
+                            <constraint firstItem="YG8-9c-nRp" firstAttribute="top" secondItem="LRj-f8-gzh" secondAttribute="bottom" id="fBC-Go-5Za"/>
                             <constraint firstItem="wpe-05-P7u" firstAttribute="top" secondItem="u2M-AS-nkI" secondAttribute="bottom" id="hsU-8N-oeZ"/>
                             <constraint firstItem="yqi-XC-h5e" firstAttribute="width" secondItem="yqi-XC-h5e" secondAttribute="height" multiplier="16:9" priority="750" id="igh-YA-jIM"/>
                             <constraint firstItem="O9k-78-gSx" firstAttribute="trailing" secondItem="QMm-yw-Spv" secondAttribute="trailing" id="jdK-iN-Dg1"/>
-                            <constraint firstItem="YG8-9c-nRp" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="kLi-3R-uaX"/>
                             <constraint firstItem="cV8-tH-dwF" firstAttribute="top" secondItem="zrS-u7-i04" secondAttribute="bottom" id="ksW-Hn-9ch"/>
                             <constraint firstItem="z4m-dy-jqD" firstAttribute="trailing" secondItem="yqi-XC-h5e" secondAttribute="trailing" constant="-50" id="nqP-nS-H1C"/>
                             <constraint firstItem="ckV-PD-W2u" firstAttribute="trailing" secondItem="O9k-78-gSx" secondAttribute="trailing" constant="-20" id="o35-Yb-svD"/>
-                            <constraint firstItem="O9k-78-gSx" firstAttribute="bottom" secondItem="YG8-9c-nRp" secondAttribute="bottom" id="oKZ-xf-Gsl"/>
                             <constraint firstItem="u2M-AS-nkI" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="qdT-KJ-HgK"/>
                             <constraint firstItem="ckV-PD-W2u" firstAttribute="top" secondItem="yqi-XC-h5e" secondAttribute="bottom" constant="10" id="rbd-EV-9jG"/>
+                            <constraint firstItem="YG8-9c-nRp" firstAttribute="centerX" secondItem="O9k-78-gSx" secondAttribute="centerX" id="scs-6n-3Pj"/>
                             <constraint firstItem="qkx-vn-sS9" firstAttribute="leading" secondItem="yqi-XC-h5e" secondAttribute="leading" constant="50" id="tg0-Zm-y6m"/>
                             <constraint firstItem="wpe-05-P7u" firstAttribute="leading" secondItem="cV8-tH-dwF" secondAttribute="leading" id="uCw-EP-wpG"/>
                         </constraints>
@@ -984,7 +951,6 @@
         <image name="pause_white" width="24" height="24"/>
         <image name="send_blueCircle" width="30" height="30"/>
         <image name="share" width="24" height="24"/>
-        <image name="square" catalog="system" width="128" height="114"/>
         <image name="thumbDown_empty" width="24" height="24"/>
         <image name="thumbUp_empty" width="24" height="24"/>
         <image name="xmark" catalog="system" width="128" height="113"/>

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/Play.storyboard
@@ -172,6 +172,9 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LcA-ew-Zmn">
                                                         <rect key="frame" x="0.0" y="0.0" width="63.5" height="41"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                        <connections>
+                                                            <action selector="likeButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="ac5-IO-nR7"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                                 <constraints>
@@ -206,6 +209,9 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gsk-u1-zcq">
                                                         <rect key="frame" x="0.0" y="0.0" width="63.5" height="41"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                        <connections>
+                                                            <action selector="dislikeButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="0nt-mg-wN7"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                                 <constraints>
@@ -274,6 +280,9 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2SI-sW-WsO">
                                                         <rect key="frame" x="0.0" y="0.0" width="63.5" height="41"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                        <connections>
+                                                            <action selector="reportButtonDidTap:" destination="zL7-Q9-x2b" eventType="touchUpInside" id="MRb-wC-cFA"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                                 <constraints>
@@ -535,8 +544,13 @@
                         <outlet property="chatSeparatorView" destination="bU7-JT-1nv" id="nE4-wW-3B4"/>
                         <outlet property="chatTextView" destination="9ux-Rl-nYc" id="VCI-zJ-8eL"/>
                         <outlet property="chatViewBottom" destination="Xyf-My-VIO" id="Qfd-rF-Nfj"/>
+                        <outlet property="dislikeButton" destination="Gsk-u1-zcq" id="NWS-gD-gPt"/>
+                        <outlet property="dislikeImageView" destination="Ygn-kh-u07" id="2Ox-yh-shG"/>
                         <outlet property="explainContainerView" destination="YG8-9c-nRp" id="dwF-b8-4OO"/>
                         <outlet property="forwardImageView" destination="z4m-dy-jqD" id="f0t-I8-gu9"/>
+                        <outlet property="likeButton" destination="LcA-ew-Zmn" id="7sy-vP-o7y"/>
+                        <outlet property="likeImageView" destination="GP6-pt-tgR" id="gFo-DS-zRv"/>
+                        <outlet property="likeLabel" destination="P6C-UC-Te0" id="ddN-fO-gXz"/>
                         <outlet property="miniBackView" destination="i9w-aJ-nVI" id="xoi-nA-u5K"/>
                         <outlet property="playControlPanGesture" destination="RCZ-cR-RhB" id="UDD-C8-uCu"/>
                         <outlet property="playControlViewSingleTap" destination="i3D-s5-2aj" id="S2e-e7-dVP"/>
@@ -548,6 +562,7 @@
                         <outlet property="playViewSingleTap" destination="QGS-uA-Xj7" id="xHD-m0-0KG"/>
                         <outlet property="playViewTop" destination="S62-GT-XAz" id="qIm-Mw-v25"/>
                         <outlet property="playViewWidth" destination="v2O-eg-KOu" id="vaK-bl-PQP"/>
+                        <outlet property="reportButton" destination="2SI-sW-WsO" id="UjP-4J-AFh"/>
                         <outlet property="safeBottomView" destination="9wx-Cn-ZFu" id="Yjc-CZ-c12"/>
                         <outlet property="safeBottomViewHeight" destination="zNw-w9-rtl" id="Jrh-Ql-hNF"/>
                         <outlet property="seekbar" destination="XbX-Kr-dZU" id="0Nw-Bg-kO5"/>

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayExplainViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayExplainViewController.swift
@@ -19,6 +19,7 @@ class PlayExplainViewController: UIViewController {
     @IBOutlet weak var explainContentLabel: UILabel!
     @IBOutlet weak var backView: UIView!
     @IBOutlet weak var scrollView: UIScrollView!
+    let viewModel = PlayViewModel()
     
     // MARK: - View Life Cycle
     override func viewDidLayoutSubviews() {
@@ -45,6 +46,11 @@ class PlayExplainViewController: UIViewController {
         channelLabel.font = UIFont.Content
         explainContentLabel.font = UIFont.caption
         explainContentLabel.textColor = UIColor.customDarkGray
+        guard let info = viewModel.currentInfo else { return }
+        videoTitleLabel.text = info.title
+        categoryLabel.text = "#\(viewModel.categoryDic[info.category] ?? "기타")"
+        channelLabel.text = (info.uploaderNickname == nil) ? info.hostNickname : info.uploaderNickname
+//        channelProfileImageView.downloadImageFrom(link: info., contentMode: <#T##UIView.ContentMode#>)
     }
     
     // MARK: - Animation

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 import Combine
 import AVFoundation
+import SwiftKeychainWrapper
 
 class PlayViewController: UIViewController {
     
@@ -29,6 +30,14 @@ class PlayViewController: UIViewController {
     @IBOutlet var playViewSingleTap: UITapGestureRecognizer!
     @IBOutlet var playControlViewSingleTap: UITapGestureRecognizer!
     var timeObserver: Any?
+    
+    @IBOutlet weak var likeImageView: UIImageView!
+    @IBOutlet weak var likeLabel: UILabel!
+    @IBOutlet weak var likeButton: UIButton!
+    
+    @IBOutlet weak var dislikeImageView: UIImageView!
+    @IBOutlet weak var dislikeButton: UIButton!
+    @IBOutlet weak var reportButton: UIButton!
     
     // mini player
     @IBOutlet weak var miniBackView: UIView!
@@ -345,6 +354,49 @@ class PlayViewController: UIViewController {
     }
     
     // MARK: - Button Action
+    
+    @IBAction func likeButtonDidTap(_ sender: Any) {
+        guard let info = viewModel.currentInfo, let uuid = KeychainWrapper.standard.string(forKey: KeychainWrapper.Key.uuid.rawValue) else { return }
+        likeButton.isEnabled = false
+        MainServiceAPI.shared.tapButtons(videoId: info.id, type: (info.hostNickname == nil ? 0 : 1), action: Action.Like, uuid: uuid) { result in
+            print("result: \(result)")
+            DispatchQueue.main.async {
+                self.likeButton.isEnabled = true
+                if result["result"] as? String == "success" {
+                    // UI 변경 및 유저정보 업데이트
+                }
+            }
+        }
+    }
+    
+    @IBAction func dislikeButtonDidTap(_ sender: Any) {
+        guard let info = viewModel.currentInfo, let uuid = KeychainWrapper.standard.string(forKey: KeychainWrapper.Key.uuid.rawValue) else { return }
+        dislikeButton.isEnabled = false
+        MainServiceAPI.shared.tapButtons(videoId: info.id, type: (info.hostNickname == nil ? 0 : 1), action: Action.Dislike, uuid: uuid) { result in
+            print("result: \(result)")
+            DispatchQueue.main.async {
+                self.dislikeButton.isEnabled = true
+                if result["result"] as? String == "success" {
+                    // UI 변경 및 유저정보 업데이트
+                }
+            }
+        }
+    }
+    
+    @IBAction func reportButtonDidTap(_ sender: Any) {
+        guard let info = viewModel.currentInfo, let uuid = KeychainWrapper.standard.string(forKey: KeychainWrapper.Key.uuid.rawValue) else { return }
+        reportButton.isEnabled = false
+        MainServiceAPI.shared.tapButtons(videoId: info.id, type: (info.hostNickname == nil ? 0 : 1), action: Action.Report, uuid: uuid) { result in
+            print("result: \(result)")
+            DispatchQueue.main.async {
+                self.reportButton.isEnabled = true
+                if result["result"] as? String == "success" {
+                    // UI 변경 및 유저정보 업데이트
+                }
+            }
+        }
+    }
+    
     func setMiniPlayerAction() {
         miniCloseButton.addTarget(self, action: #selector(miniCLoseButtonDidTap), for: .touchUpInside)
         miniPlayPauseButton.addTarget(self, action: #selector(miniPlayPauseButtonDidTap), for: .touchUpInside)

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -346,6 +346,8 @@ class PlayViewController: UIViewController {
                 self.miniTitleLabel.text = info.title
                 self.miniChannelNameLabel.text = (info.uploaderNickname == nil) ? info.hostNickname : info.uploaderNickname
         //        channelProfileImageView.downloadImageFrom(link: info., contentMode: <#T##UIView.ContentMode#>)
+                self.playControllView.isHidden = self.viewModel.isLive
+                self.miniPlayPauseButton.alpha = self.viewModel.isLive ? 0 : 1
                 self.setPlayer(urlInfo: info.fileLink ?? "")
                 self.connectChatView()
             }.store(in: &cancellable)
@@ -496,6 +498,7 @@ class PlayViewController: UIViewController {
         if isMinimized {
             self.setPlayViewOriginalSize()
         } else {
+            if self.viewModel.isLive { return }
             self.playControllTimer.invalidate()
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
                 self.playControllView.alpha = 1

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -31,6 +31,7 @@ class PlayViewController: UIViewController {
     @IBOutlet var playControlViewSingleTap: UITapGestureRecognizer!
     var timeObserver: Any?
     @IBOutlet weak var seekbarBackView: UIView!
+    var didEndPlay = false
     
     // button action
     @IBOutlet weak var likeImageView: UIImageView!
@@ -250,6 +251,7 @@ class PlayViewController: UIViewController {
     }
 
     @objc func playerDidFinishPlaying() {
+        self.didEndPlay = true
         self.isPlay = false
     }
     
@@ -351,6 +353,7 @@ class PlayViewController: UIViewController {
             .sink { [weak self] tf in
                 guard let self = self else { return }
                 if tf {
+                    if self.didEndPlay { self.isPlay = false }
                     self.playView.player?.play()
                     self.miniPlayPauseButton.setImage(UIImage(named: "pause_black"), for: .normal)
                     self.playPauseButton.setImage(UIImage(named: "pause_white"), for: .normal)

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -30,6 +30,7 @@ class PlayViewController: UIViewController {
     @IBOutlet var playViewSingleTap: UITapGestureRecognizer!
     @IBOutlet var playControlViewSingleTap: UITapGestureRecognizer!
     var timeObserver: Any?
+    @IBOutlet weak var seekbarBackView: UIView!
     
     @IBOutlet weak var likeImageView: UIImageView!
     @IBOutlet weak var likeLabel: UILabel!
@@ -666,5 +667,16 @@ extension PlayViewController {
             chatViewBottom.constant = 0
             self.view.layoutIfNeeded()
         }
+    }
+}
+
+extension PlayViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if touch.view?.isDescendant(of: self.seekbarBackView) == true {
+            return false
+        } else if touch.view?.isDescendant(of: self.seekbar) == true {
+            return false
+        }
+        return true
     }
 }

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -569,7 +569,7 @@ class PlayViewController: UIViewController {
     }
     
     @objc func handleDoubleTap(gestureRecognizer: UITapGestureRecognizer) {
-        if isMinimized { return }
+        if isMinimized || self.viewModel.isLive { return }
         let point = gestureRecognizer.location(in: self.playView)
         let halfPosition = playView.frame.width / 2
         if point.x < (halfPosition - 30) {

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewController.swift
@@ -346,6 +346,7 @@ class PlayViewController: UIViewController {
                 self.miniTitleLabel.text = info.title
                 self.miniChannelNameLabel.text = (info.uploaderNickname == nil) ? info.hostNickname : info.uploaderNickname
         //        channelProfileImageView.downloadImageFrom(link: info., contentMode: <#T##UIView.ContentMode#>)
+                self.viewLabel.text = info.hits == nil ? "" : "조회수 \(info.hits ?? 0)회"
                 self.playControllView.isHidden = self.viewModel.isLive
                 self.miniPlayPauseButton.alpha = self.viewModel.isLive ? 0 : 1
                 self.setPlayer(urlInfo: info.fileLink ?? "")

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  PlayViewModel.swift
+//  PlayGround
+//
+//  Created by chuiseo-MN on 2022/02/01.
+//
+
+import Foundation
+import UIKit
+
+class PlayViewModel {
+    var currentInfo: GeneralVideo?
+}

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 import UIKit
+import Combine
 
 class PlayViewModel {
-    var currentInfo: GeneralVideo?
+    let categoryDic = ["ALL": "전체", "EDU": "교육", "SPORTS": "스포츠", "KPOP": "K-POP"]
+    
+    @Published var currentInfo: GeneralVideo?
 }

--- a/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Video/Play/PlayViewModel.swift
@@ -13,4 +13,11 @@ class PlayViewModel {
     let categoryDic = ["ALL": "전체", "EDU": "교육", "SPORTS": "스포츠", "KPOP": "K-POP"]
     
     @Published var currentInfo: GeneralVideo?
+    
+    var isLive: Bool {
+        guard let info = currentInfo else {
+            return false
+        }
+        return (info.hostNickname != nil)
+    }
 }


### PR DESCRIPTION
/list api 연결
- 홈화면 영상 리스트 조회 (전체 / 카테고리별)
- 인피니트 스크롤 도입
- 자동재생 해당 영상의 fileLink 주소로 변경
- 재생 화면에서 더미 값이 아니라 해당 영상의 정보가 보이도록 변경
- live일 때와 video일 때 달라져야 하는 UI (ex. 재생 버튼 등은 live일 때 안 보이도록, 앞뒤로 10초 이동하는 제스처 live일 때 인식 안되도록) 적용 


https://user-images.githubusercontent.com/73422344/152179473-c2b2fc7a-6526-4a87-ba54-b04931c0e1cb.mp4
