### PR TITLE
design : remove corner radius before saving profile image

### DIFF
--- a/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/NickNameInputViewController.swift
+++ b/src/ios/PlayGround/PlayGround/Presentation/Register/ViewControllers/NickNameInputViewController.swift
@@ -38,6 +38,13 @@ class NickNameInputViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+//        let image = profileView.snapshotView(afterScreenUpdates: true)?.takeScreenshot()
+//        RegisterHelper.shared.profileImage = image
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        profileView.layer.cornerRadius = 0
         let image = profileView.snapshotView(afterScreenUpdates: true)?.takeScreenshot()
         RegisterHelper.shared.profileImage = image
     }


### PR DESCRIPTION
Resolved #129 
회원가입 중 자동생성된 프로필에 corner radius가 적용되어서 저장되는 이슈 해결
- 사진 내부적으로 저장되는 타이밍 변경
- 저장 직전 corner radius 삭제