### PR TITLE
feat, refactor : create upload (after live) api

### DIFF
--- a/src/server/main-service/src/main/java/com/example/mainservice/entity/User/User.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/entity/User/User.java
@@ -76,7 +76,7 @@ public class User {
     private List<ViewedHistory> viewedHistories = new LinkedList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Room> lives = new ArrayList<>();
+    private List<Room> rooms = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     private List<Notification> notifications = new LinkedList<>();

--- a/src/server/main-service/src/main/java/com/example/mainservice/entity/ViewdHistory/ViewedHistory.java
+++ b/src/server/main-service/src/main/java/com/example/mainservice/entity/ViewdHistory/ViewedHistory.java
@@ -37,8 +37,6 @@ public class ViewedHistory {
     public ViewedHistory(User user, Video video) {
         this.user = user;
         this.video = video;
-        user.getViewedHistories().add(this);
-        video.getViewedHistories().add(this);
     }
 
     public void setLiked(boolean liked) {

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
@@ -2,6 +2,7 @@ package com.example.uploadservice.controller;
 
 import com.example.uploadservice.dto.UploadRequestDto;
 import com.example.uploadservice.dto.VideoDto;
+import com.example.uploadservice.entity.Video.Video;
 import com.example.uploadservice.exceptionHandler.customexception.CustomUploadException;
 import com.example.uploadservice.service.TranscodeService;
 import com.example.uploadservice.service.UploadService;
@@ -10,15 +11,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
+@RequestMapping("/upload")
 @RestController
 public class UploadController {
 
@@ -26,10 +26,10 @@ public class UploadController {
     private final UploadService uploadService;
     private final TranscodeService transcodeService;
 
-    @PostMapping(value = "/upload", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Map<String, String>> video(@RequestPart(value = "video") MultipartFile multipartFileVideo,
-                                        @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
-                                        @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
+                                                     @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
+                                                     @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
         VideoDto videoDto = new VideoDto(dto);
         String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
         transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
@@ -37,6 +37,23 @@ public class UploadController {
         videoDto.updateMetaData(s3OutputPath);
         videoService.add(videoDto);
 
+        return ResponseEntity.ok(Map.of("result", "success"));
+    }
+
+    @PostMapping(value="/live/{roomId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Map<String, String>> live(@RequestPart(value = "video") MultipartFile multipartFileVideo,
+                                                    @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
+                                                    @RequestPart(value = "data") UploadRequestDto dto,
+                                                    @PathVariable(value = "roomId") Long roomId) throws CustomUploadException  {
+
+        VideoDto videoDto = new VideoDto(dto);
+        String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
+        transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
+        String s3OutputPath = uploadService.uploadTranscodedFile(videoUuid);
+        videoDto.updateMetaData(s3OutputPath);
+
+        Video video = videoService.add(videoDto);
+        videoService.remove(video, roomId);
         return ResponseEntity.ok(Map.of("result", "success"));
     }
 }

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
@@ -30,7 +30,7 @@ public class UploadController {
     public ResponseEntity<Map<String, String>> video(@RequestPart(value = "video") MultipartFile multipartFileVideo,
                                                      @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
                                                      @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
-        VideoDto videoDto = new VideoDto(dto);
+        VideoDto videoDto = new VideoDto(dto, multipartFileThumbnail.getOriginalFilename());
         String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
         transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
         String s3OutputPath = uploadService.uploadTranscodedFile(videoUuid);
@@ -46,7 +46,7 @@ public class UploadController {
                                                     @RequestPart(value = "data") UploadRequestDto dto,
                                                     @PathVariable(value = "roomId") Long roomId) throws CustomUploadException  {
 
-        VideoDto videoDto = new VideoDto(dto);
+        VideoDto videoDto = new VideoDto(dto, multipartFileThumbnail.getOriginalFilename());
         String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
         transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
         String s3OutputPath = uploadService.uploadTranscodedFile(videoUuid);
@@ -54,6 +54,13 @@ public class UploadController {
 
         Video video = videoService.add(videoDto);
         videoService.remove(video, roomId);
+        return ResponseEntity.ok(Map.of("result", "success"));
+    }
+
+    @PostMapping(value="/aws-converter", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Map<String, String>> videoByAwsConverter (@RequestPart(value = "video") MultipartFile multipartFileVideo,
+                                                     @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
+                                                     @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
         return ResponseEntity.ok(Map.of("result", "success"));
     }
 }

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/controller/UploadController.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @RestController
 public class UploadController {
 
+    private static final String DEFAULT_THUMBNAIL_NAME = "thumbnail";
     private final VideoService videoService;
     private final UploadService uploadService;
     private final TranscodeService transcodeService;
@@ -30,7 +31,7 @@ public class UploadController {
     public ResponseEntity<Map<String, String>> video(@RequestPart(value = "video") MultipartFile multipartFileVideo,
                                                      @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
                                                      @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
-        VideoDto videoDto = new VideoDto(dto, multipartFileThumbnail.getOriginalFilename());
+        VideoDto videoDto = new VideoDto(dto, getOutputThumbnailName(multipartFileThumbnail.getOriginalFilename()));
         String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
         transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
         String s3OutputPath = uploadService.uploadTranscodedFile(videoUuid);
@@ -46,7 +47,7 @@ public class UploadController {
                                                     @RequestPart(value = "data") UploadRequestDto dto,
                                                     @PathVariable(value = "roomId") Long roomId) throws CustomUploadException  {
 
-        VideoDto videoDto = new VideoDto(dto, multipartFileThumbnail.getOriginalFilename());
+        VideoDto videoDto = new VideoDto(dto, getOutputThumbnailName(multipartFileThumbnail.getOriginalFilename()));
         String videoUuid = uploadService.uploadRawFile(multipartFileVideo, multipartFileThumbnail, videoDto);
         transcodeService.convertMp4ToTs(videoUuid, multipartFileThumbnail);
         String s3OutputPath = uploadService.uploadTranscodedFile(videoUuid);
@@ -62,5 +63,9 @@ public class UploadController {
                                                      @RequestPart(value = "thumbnail", required = false) MultipartFile multipartFileThumbnail,
                                                      @RequestPart(value = "data") UploadRequestDto dto) throws CustomUploadException  {
         return ResponseEntity.ok(Map.of("result", "success"));
+    }
+
+    private String getOutputThumbnailName(String name){
+        return DEFAULT_THUMBNAIL_NAME + "." + name.split("\\.")[1];
     }
 }

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/dto/VideoDto.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/dto/VideoDto.java
@@ -14,15 +14,17 @@ public class VideoDto {
     private Category category;
     private String videoUuid;
     private String uploaderUuid;
+    private String thumbnailName;
     private String s3OutputPath; // folder path
     private Long size;
     private LocalDateTime videoCreatedAt;
 
-    public VideoDto(UploadRequestDto dto){
+    public VideoDto(UploadRequestDto dto, String thumbnailName){
         this.title = dto.getTitle();
         this.content = dto.getContent();
         this.category = dto.getCategory();
         this.uploaderUuid = dto.getUuid();
+        this.thumbnailName = thumbnailName;
     }
 
     /**

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/Room/Room.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/Room/Room.java
@@ -1,0 +1,53 @@
+package com.example.uploadservice.entity.Room;
+
+import com.example.uploadservice.entity.Category;
+import com.example.uploadservice.entity.RoomViewer.RoomViewer;
+import com.example.uploadservice.entity.User.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@NoArgsConstructor
+@Getter
+@Entity
+public class Room {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 36)
+    private String uuid;    // use for chat, room
+
+    @Column(length = 36)
+    private String hostUuid;
+
+    @Column(length = 100)
+    private String title;
+
+    @Column(length = 5000)
+    private String content;
+
+    @Column(columnDefinition = "TEXT")
+    private String thumbnail;
+
+    private int likeCnt;
+
+    private short reportCnt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Category category;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "users_id")
+    private User user;
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomViewer> roomViewers;
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/Room/RoomRepository.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/Room/RoomRepository.java
@@ -1,0 +1,15 @@
+package com.example.uploadservice.entity.Room;
+
+import com.example.uploadservice.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    @Query("SELECT r FROM Room r ORDER BY r.createdAt DESC")
+    Page<Room> findAll(Pageable pageable);
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/RoomViewer/RoomViewer.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/RoomViewer/RoomViewer.java
@@ -1,0 +1,49 @@
+package com.example.uploadservice.entity.RoomViewer;
+
+import com.example.uploadservice.entity.Room.Room;
+import com.example.uploadservice.entity.User.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class RoomViewer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean liked = false;
+
+    private boolean disliked = false;
+
+    private LocalDateTime likedAt;
+
+    private LocalDateTime lastViewedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "users_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    public RoomViewer(User user, Room room) {
+        this.user = user;
+        this.room = room;
+        user.getRoomViewers().add(this);
+        room.getRoomViewers().add(this);
+    }
+
+    public void setLiked(boolean liked) {
+        this.liked = liked;
+        this.likedAt = LocalDateTime.now();
+    }
+
+    public void setDisliked(boolean disliked) {
+        this.disliked = disliked;
+    }
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/RoomViewer/RoomViewerRepository.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/RoomViewer/RoomViewerRepository.java
@@ -1,0 +1,11 @@
+package com.example.uploadservice.entity.RoomViewer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.Optional;
+
+public interface RoomViewerRepository extends JpaRepository<RoomViewer, Long>{
+    @Query("SELECT r FROM RoomViewer r WHERE r.user.uuid = :userUuid AND r.room.id = :roomId")
+    Optional<RoomViewer> findByLiveRoomIdAndUserUuid(@Param("userUuid")String userUuid, @Param("roomId")Long roomId);
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/User/User.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/User/User.java
@@ -1,6 +1,9 @@
 package com.example.uploadservice.entity.User;
 
+import com.example.uploadservice.entity.Room.Room;
+import com.example.uploadservice.entity.RoomViewer.RoomViewer;
 import com.example.uploadservice.entity.Video.Video;
+import com.example.uploadservice.entity.ViewdHistory.ViewedHistory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +64,14 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Video> videos = new LinkedList<>();
 
+    @OneToMany(mappedBy = "user")
+    private List<RoomViewer> roomViewers = new LinkedList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<ViewedHistory> viewedHistories = new LinkedList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Room> rooms = new ArrayList<>();
     /**
      * =============Friend=============
      **/

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/ViewdHistory/ViewedHistory.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/ViewdHistory/ViewedHistory.java
@@ -1,0 +1,59 @@
+package com.example.uploadservice.entity.ViewdHistory;
+
+import com.example.uploadservice.entity.RoomViewer.RoomViewer;
+import com.example.uploadservice.entity.User.User;
+import com.example.uploadservice.entity.Video.Video;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class ViewedHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long viewedProgress; // ms
+
+    private boolean liked = false;
+
+    private boolean disliked = false;
+
+    private LocalDateTime likedAt;
+
+    private LocalDateTime lastViewedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "video_id")
+    private Video video;
+
+    @ManyToOne
+    @JoinColumn(name = "users_id")
+    private User user;
+
+    public ViewedHistory(User user, Video video) {
+        this.user = user;
+        this.video = video;
+    }
+
+    public ViewedHistory(RoomViewer roomViewer, Video video){
+        this.liked = roomViewer.isLiked();
+        this.disliked = roomViewer.isDisliked();
+        this.likedAt = roomViewer.getLikedAt();
+        this.lastViewedAt = roomViewer.getLastViewedAt();
+        this.user = roomViewer.getUser();
+        this.video = video;
+    }
+
+    public void setLiked(boolean liked) {
+        this.liked = liked;
+        this.likedAt = liked? LocalDateTime.now(): null;
+    }
+
+    public void setDisliked(boolean disliked) {
+        this.disliked = disliked;
+    }
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/entity/ViewdHistory/ViewedRepository.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/entity/ViewdHistory/ViewedRepository.java
@@ -1,0 +1,7 @@
+package com.example.uploadservice.entity.ViewdHistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ViewedRepository extends JpaRepository<ViewedHistory, Long>{
+
+}

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/service/TranscodeService.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/service/TranscodeService.java
@@ -27,7 +27,6 @@ public class TranscodeService {
     private final String LOCAL_FILEPATH;
     private final String FFMPEG_PATH;
     private final String FFPROBE_PATH;
-    private final AmazonS3 amazonS3;
 
     @Autowired
     public TranscodeService(@Value("${cloud.aws.s3.image.domain}") String s3Domain,
@@ -35,15 +34,13 @@ public class TranscodeService {
                             @Value("${cloud.aws.s3.image.bucket}") String bucket,
                             @Value("${cloud.aws.s3.image.input-dir}") String inputDir,
                             @Value("${ffmpeg.path}") String ffmpegPath,
-                            @Value("${ffprobe.path}") String ffprobePath,
-                            AmazonS3 amazonS3) {
+                            @Value("${ffprobe.path}") String ffprobePath){
         this.S3_DOMAIN= s3Domain;
         this.BUCKET = bucket;
         this.INPUT_DIR = inputDir;
         this.LOCAL_FILEPATH = localFilePath;
         this.FFMPEG_PATH = ffmpegPath;
         this.FFPROBE_PATH = ffprobePath;
-        this.amazonS3 = amazonS3;
     }
 
     public void convertMp4ToTs(String videoUuid, MultipartFile multipartFileThumbnail) throws CustomUploadException {

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/service/VideoService.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/service/VideoService.java
@@ -26,7 +26,6 @@ public class VideoService {
 
     private static final String DEFAULT_M3U8_FILE = "video.m3u8";
     private static final String DEFAULT_VIDEO_FILE = "video.mp4";
-    private static final String DEFAULT_THUMBNAIL_FILE = "thumbnail.png";
     private final VideoRepository videoRepository;
     private final UserRepository userRepository;
     private final RoomRepository roomRepository;
@@ -50,7 +49,7 @@ public class VideoService {
                 .content(dto.getContent())
                 .category(dto.getCategory())
                 .uuid(dto.getVideoUuid())
-                .thumbnail(dto.getS3OutputPath() + "/" + DEFAULT_THUMBNAIL_FILE)
+                .thumbnail(dto.getS3OutputPath() + "/" + dto.getThumbnailName())
                 .user(user)
                 .build();
 

--- a/src/server/upload-service/src/main/java/com/example/uploadservice/service/VideoService.java
+++ b/src/server/upload-service/src/main/java/com/example/uploadservice/service/VideoService.java
@@ -3,15 +3,22 @@ package com.example.uploadservice.service;
 import com.example.uploadservice.dto.VideoDto;
 import com.example.uploadservice.entity.Metadata.Metadata;
 import com.example.uploadservice.entity.Metadata.MetadataRepository;
+import com.example.uploadservice.entity.Room.Room;
+import com.example.uploadservice.entity.Room.RoomRepository;
+import com.example.uploadservice.entity.RoomViewer.RoomViewerRepository;
 import com.example.uploadservice.entity.User.User;
 import com.example.uploadservice.entity.User.UserRepository;
 import com.example.uploadservice.entity.Video.Video;
 import com.example.uploadservice.entity.Video.VideoRepository;
+import com.example.uploadservice.entity.ViewdHistory.ViewedHistory;
+import com.example.uploadservice.entity.ViewdHistory.ViewedRepository;
 import com.example.uploadservice.exceptionHandler.customexception.CustomUploadException;
 import com.example.uploadservice.exceptionHandler.customexception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -22,10 +29,13 @@ public class VideoService {
     private static final String DEFAULT_THUMBNAIL_FILE = "thumbnail.png";
     private final VideoRepository videoRepository;
     private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final RoomViewerRepository roomViewerRepository;
+    private final ViewedRepository viewedRepository;
     private final MetadataRepository metadataRepository;
 
     @Transactional
-    public void add(VideoDto dto){
+    public Video add(VideoDto dto){
         User user = userRepository.findByUuid(dto.getUploaderUuid())
                 .orElseThrow(() -> new CustomUploadException(ErrorCode.U002));
         Metadata metadata = Metadata.builder()
@@ -45,7 +55,22 @@ public class VideoService {
                 .build();
 
         metadataRepository.save(metadata);
-        videoRepository.save(video);
         video.setMetadata(metadata);
+        return videoRepository.save(video);
+    }
+
+    @Transactional
+    public void remove(Video video, Long roomId) throws CustomUploadException{
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new CustomUploadException(ErrorCode.L001));
+        if(room.getRoomViewers() != null) {
+            List<ViewedHistory> viewedHistories = room.getRoomViewers()
+                    .stream()
+                    .map(roomViewer -> new ViewedHistory(roomViewer, video))
+                    .collect(Collectors.toList());
+            viewedRepository.saveAll(viewedHistories);
+            roomViewerRepository.deleteAll(room.getRoomViewers());
+        }
+
+        roomRepository.delete(room);
     }
 }

--- a/src/server/upload-service/src/main/resources/application.yml
+++ b/src/server/upload-service/src/main/resources/application.yml
@@ -17,8 +17,8 @@ spring:
       enabled: true
 #      file-size-threshold:  #??? ???? ???? ??? (default: 0B)
 #      location:               #???? ??? ?? ?? ??
-      max-file-size: 5MB
-      max-request-size: 5MB
+      max-file-size: 100MB
+      max-request-size: 100MB
 
 ---
 spring.config.activate.on-profile: local


### PR DESCRIPTION
- 작동 순서
```
영상 기본 업로드(1~4) 에 5추가한 형태
1. client에서 원본파일 업로드 -> s3에 저장
2. s3에 저장된 파일을 transcode하여 로컬에 임시 저장
3. 임시 저장된 ts, m3u8 파일들을 s3에 업로드 & 로컬에서 삭제
4. Mariadb Video 테이블에 Video, Metadata 데이터 추가, VIdeo-User 연관관계 설정하여 저장
5. 해당 Room, RoomViewer테이블의 데이터 삭제 후 시청기록에 대한 동일한 데이터 ViewedHistory에 추가
```
